### PR TITLE
feat: copy posted message to clipboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ pnpm lint:fix
 - Entry points (file-based, picked up automatically by WXT):
   - `src/entrypoints/background.ts` - Service worker (wraps logic in `defineBackground`)
   - `src/entrypoints/options/{index.html,main.ts}` - Options page Vue app entry
+  - `src/entrypoints/offscreen/{index.html,main.ts}` - Offscreen document used to write to the clipboard from the service worker (built to `offscreen.html` at extension root)
 - Static assets:
   - `public/icon/{16,48,128}.png` - Extension icons (auto-discovered by WXT)
 - Manifest is defined in `wxt.config.ts` as a function of `{ mode }`; WXT auto-fills `manifest_version`, `icons`, `options_ui`, and `background.service_worker` from the file layout
@@ -58,14 +59,21 @@ pnpm lint:fix
 
 **Data Layer**
 
-- `BskyRepository` - Bluesky API interactions using `@atproto/api`
-- `ConfigLocalGateway` - Chrome storage abstraction for session persistence
-- `PostTemplateRepository` - User-configurable post templates
+Layered as **Gateway → Repository → consumers**. The gateway is the low-level
+storage abstraction; repositories are the domain-facing API. **Always go through
+a repository from `OmniATP`, Vue components, or any other consumer — never call
+`ConfigLocalGateway` directly outside `src/data/`.** A repository may look like a
+thin pass-through today; that's the layer's purpose, not a smell.
+
+- `ConfigLocalGateway` - Chrome storage abstraction (sessions, post prefix, app preferences). Internal to `src/data/`.
+- `BskyRepository` - Bluesky API interactions using `@atproto/api`; persists session via `ConfigLocalGateway`.
+- `PostTemplateRepository` - User-configurable post template (wraps `ConfigLocalGateway` post-prefix into the `PostTemplate` model).
+- `AppPreferencesRepository` - App-level user preferences (e.g. `copyToClipboardOnPost`).
 
 **Platform Abstraction**
 
-- `ChromeDelegate` (`src/platform/ChromeDelegate.ts`) - Wraps Chrome extension APIs
-- `ChromeStorageDelegate` - Wraps Chrome storage API
+- `ChromeDelegate` (`src/platform/ChromeDelegate.ts`) - Wraps Chrome extension APIs. `copyToClipboard()` lazily creates the offscreen document declared in `src/entrypoints/offscreen/` and posts a message to it (see `src/platform/offscreen-messages.ts` for the wire format).
+- `ChromeStorageDelegate` - Wraps Chrome storage API.
 
 ### Tech Stack
 
@@ -80,3 +88,5 @@ pnpm lint:fix
 - `defineBackground` is auto-imported by WXT — do not add `import` statements for it
 - `tsconfig.json` extends `./.wxt/tsconfig.json`, which is regenerated on every `wxt prepare`. Do not commit `.wxt/`
 - The notification icon path passed to `chrome.notifications.create` must be `'icon/128.png'` (extension-root relative); files under `public/` are emitted to the extension root by WXT
+- Offscreen clipboard writes require **both** the `offscreen` and `clipboardWrite` permissions in `wxt.config.ts`. The CLIPBOARD reason alone is not sufficient — `execCommand('copy')` silently returns false without `clipboardWrite`.
+- `navigator.clipboard.writeText` is unusable from the offscreen document (it rejects with "Document is not focused" because offscreen documents are never focused by design). Use the `<textarea> + document.execCommand('copy')` pattern in `src/entrypoints/offscreen/main.ts`, and call `window.close()` after each copy so the next call runs against a freshly-loaded page (reusing the document makes execCommand fail on later invocations).

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@ import { LoginCredential } from './data/model/LoginCredential'
 const component = createOptionsComponent(chrome)
 
 const _postTemplate = ref<PostTemplate>(PostTemplate.empty())
+const _copyToClipboardOnPost = ref<boolean>(false)
 
 const service = BskyConfig.service
 const appVersion = component.chromeDelegate().appVersion()
@@ -29,6 +30,14 @@ const postTemplate = computed<PostTemplate>({
   set: (value) => {
     _postTemplate.value = value
     component.postTemplateRepository().save(value)
+  },
+})
+
+const copyToClipboardOnPost = computed<boolean>({
+  get: () => _copyToClipboardOnPost.value,
+  set: (value) => {
+    _copyToClipboardOnPost.value = value
+    component.appPreferencesRepository().setCopyToClipboardOnPost(value)
   },
 })
 
@@ -57,15 +66,19 @@ onMounted(async () => {
   const repo = component.bskyRepository()
   await repo.resumeSession()
 
-  const p = await repo.getProfile()
+  const [p, template, copyOnPost] = await Promise.all([
+    repo.getProfile(),
+    component.postTemplateRepository().get(),
+    component.appPreferencesRepository().getCopyToClipboardOnPost(),
+  ])
+
   console.log('profile', p)
   profile.value = p
-
   authProgress.value = p
     ? AuthProgress.AUTHORIZED()
     : AuthProgress.UNAUTHORIZED()
-
-  _postTemplate.value = await component.postTemplateRepository().get()
+  _postTemplate.value = template
+  _copyToClipboardOnPost.value = copyOnPost
 })
 </script>
 
@@ -77,6 +90,7 @@ onMounted(async () => {
     <main class="max-w-4xl w-full flex-grow">
       <SettingsList
         v-model:post-template="postTemplate"
+        v-model:copy-to-clipboard-on-post="copyToClipboardOnPost"
         v-model:auth-progress="authProgress"
         class="w-full"
         :service="service"

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,7 +69,7 @@ onMounted(async () => {
   const [p, template, copyOnPost] = await Promise.all([
     repo.getProfile(),
     component.postTemplateRepository().get(),
-    component.appPreferencesRepository().getCopyToClipboardOnPost(),
+    component.appPreferencesRepository().shouldCopyToClipboardOnPost(),
   ])
 
   console.log('profile', p)

--- a/src/background/OmniATP.ts
+++ b/src/background/OmniATP.ts
@@ -1,6 +1,7 @@
 import { ChromeDelegate } from '../platform/ChromeDelegate'
 import { Clock } from '../Clock'
 import { BskyRepository } from '../data/BskyRepository'
+import { AppPreferencesRepository } from '../data/AppPreferencesRepository'
 import { Payload, SubCommand } from './SubCommands'
 import { XRPCError } from '@atproto/xrpc'
 
@@ -20,6 +21,7 @@ export class OmniATP {
     readonly clock: Clock,
     readonly chrome: ChromeDelegate,
     readonly bskyRepository: BskyRepository,
+    readonly appPreferencesRepository: AppPreferencesRepository,
     readonly subCommands: SubCommand[]
   ) {}
 
@@ -58,6 +60,14 @@ export class OmniATP {
         this.chrome.appName(),
         payload.message
       )
+
+      if (await this.appPreferencesRepository.getCopyToClipboardOnPost()) {
+        try {
+          await this.chrome.copyToClipboard(payload.message)
+        } catch (clipboardError) {
+          console.error('Failed to copy to clipboard', clipboardError)
+        }
+      }
     } catch (e) {
       const { status, error } = extractError(e)
       this.chrome.createNotification(

--- a/src/background/OmniATP.ts
+++ b/src/background/OmniATP.ts
@@ -61,7 +61,7 @@ export class OmniATP {
         payload.message
       )
 
-      if (await this.appPreferencesRepository.getCopyToClipboardOnPost()) {
+      if (await this.appPreferencesRepository.shouldCopyToClipboardOnPost()) {
         try {
           await this.chrome.copyToClipboard(payload.message)
         } catch (clipboardError) {

--- a/src/components/SettingsList/CopyToClipboardItem.vue
+++ b/src/components/SettingsList/CopyToClipboardItem.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Switch } from '@headlessui/vue'
+import SettingsListItem from './SettingsListItem.vue'
+
+const props = defineProps<{ enabled: boolean }>()
+
+const emit = defineEmits<{
+  (event: 'update:enabled', value: boolean): void
+}>()
+
+const enabledRef = computed({
+  get: () => props.enabled,
+  set: (value) => emit('update:enabled', value),
+})
+</script>
+
+<template>
+  <SettingsListItem inner-class="!flex items-center justify-between">
+    <div>
+      <p>Copy to clipboard on post</p>
+      <div class="text-gray-600 text-sm">
+        Copy the posted message text to your clipboard after a successful post.
+      </div>
+    </div>
+    <Switch
+      v-model="enabledRef"
+      :class="[
+        enabledRef ? 'bg-blue-600' : 'bg-gray-200',
+        'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
+      ]"
+    >
+      <span class="sr-only">Toggle copy to clipboard on post</span>
+      <span
+        aria-hidden="true"
+        :class="[
+          enabledRef ? 'translate-x-5' : 'translate-x-0',
+          'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+        ]"
+      />
+    </Switch>
+  </SettingsListItem>
+</template>

--- a/src/components/SettingsList/SettingsList.vue
+++ b/src/components/SettingsList/SettingsList.vue
@@ -2,6 +2,7 @@
 import { PostTemplate } from '../../data/model/PostTemplate'
 import AuthItem from './AuthItem.vue'
 import PostPrefixItem from './PostPrefixItem.vue'
+import CopyToClipboardItem from './CopyToClipboardItem.vue'
 import SettingsListHeader from './SettingsListHeader.vue'
 import { AppBskyActorDefs } from '@atproto/api'
 import SettingsListItem from './SettingsListItem.vue'
@@ -15,6 +16,7 @@ const props = defineProps<{
   service: string
   profile?: AppBskyActorDefs.ProfileViewDetailed
   postTemplate: PostTemplate
+  copyToClipboardOnPost: boolean
   appVersion: string
   developer: Developer
   storeUrl: string
@@ -25,6 +27,7 @@ const emit = defineEmits<{
   (event: 'signin', value: LoginCredential): void
   (event: 'signout'): void
   (event: 'update:postTemplate', value: PostTemplate): void
+  (event: 'update:copyToClipboardOnPost', value: boolean): void
   (event: 'update:authProgress', value: AuthProgress): void
 }>()
 
@@ -36,6 +39,10 @@ const authProgress = computed({
 const handleUpdatePrefix = (prefix: string) => {
   const newTemplate = new PostTemplate(prefix)
   emit('update:postTemplate', newTemplate)
+}
+
+const handleUpdateCopyToClipboard = (value: boolean) => {
+  emit('update:copyToClipboardOnPost', value)
 }
 </script>
 
@@ -55,6 +62,10 @@ const handleUpdatePrefix = (prefix: string) => {
       <PostPrefixItem
         :prefix="postTemplate.prefix"
         @update:prefix="handleUpdatePrefix"
+      />
+      <CopyToClipboardItem
+        :enabled="copyToClipboardOnPost"
+        @update:enabled="handleUpdateCopyToClipboard"
       />
       <SettingsListHeader title="Others" />
       <SettingsListItem class="!border-t-0">

--- a/src/data/AppPreferencesRepository.ts
+++ b/src/data/AppPreferencesRepository.ts
@@ -1,0 +1,20 @@
+import { ConfigLocalGateway } from './ConfigLocalGateway'
+
+export interface AppPreferencesRepository {
+  getCopyToClipboardOnPost(): Promise<boolean>
+  setCopyToClipboardOnPost(value: boolean): Promise<void>
+}
+
+export class DefaultAppPreferencesRepository
+  implements AppPreferencesRepository
+{
+  constructor(readonly localGateway: ConfigLocalGateway) {}
+
+  getCopyToClipboardOnPost(): Promise<boolean> {
+    return this.localGateway.getCopyToClipboardOnPost()
+  }
+
+  setCopyToClipboardOnPost(value: boolean): Promise<void> {
+    return this.localGateway.saveCopyToClipboardOnPost(value)
+  }
+}

--- a/src/data/AppPreferencesRepository.ts
+++ b/src/data/AppPreferencesRepository.ts
@@ -1,7 +1,7 @@
 import { ConfigLocalGateway } from './ConfigLocalGateway'
 
 export interface AppPreferencesRepository {
-  getCopyToClipboardOnPost(): Promise<boolean>
+  shouldCopyToClipboardOnPost(): Promise<boolean>
   setCopyToClipboardOnPost(value: boolean): Promise<void>
 }
 
@@ -10,8 +10,8 @@ export class DefaultAppPreferencesRepository
 {
   constructor(readonly localGateway: ConfigLocalGateway) {}
 
-  getCopyToClipboardOnPost(): Promise<boolean> {
-    return this.localGateway.getCopyToClipboardOnPost()
+  shouldCopyToClipboardOnPost(): Promise<boolean> {
+    return this.localGateway.shouldCopyToClipboardOnPost()
   }
 
   setCopyToClipboardOnPost(value: boolean): Promise<void> {

--- a/src/data/ConfigLocalGateway.ts
+++ b/src/data/ConfigLocalGateway.ts
@@ -6,7 +6,7 @@ export interface ConfigLocalGateway {
   savePostPrefix(prefix: string): Promise<void>
   clearPostPrefix(): Promise<void>
 
-  getCopyToClipboardOnPost(): Promise<boolean>
+  shouldCopyToClipboardOnPost(): Promise<boolean>
   saveCopyToClipboardOnPost(value: boolean): Promise<void>
 
   saveSession(session: AtpSessionData): Promise<void>
@@ -35,7 +35,7 @@ export class DefaultConfigLocalGateway implements ConfigLocalGateway {
     await this.storage.remove(['postPrefix'])
   }
 
-  async getCopyToClipboardOnPost(): Promise<boolean> {
+  async shouldCopyToClipboardOnPost(): Promise<boolean> {
     const { copyToClipboardOnPost } = await this.storage.get({
       copyToClipboardOnPost: false,
     })

--- a/src/data/ConfigLocalGateway.ts
+++ b/src/data/ConfigLocalGateway.ts
@@ -6,6 +6,9 @@ export interface ConfigLocalGateway {
   savePostPrefix(prefix: string): Promise<void>
   clearPostPrefix(): Promise<void>
 
+  getCopyToClipboardOnPost(): Promise<boolean>
+  saveCopyToClipboardOnPost(value: boolean): Promise<void>
+
   saveSession(session: AtpSessionData): Promise<void>
   getSession(): Promise<AtpSessionData | undefined>
   clearSession(): Promise<void>
@@ -30,6 +33,17 @@ export class DefaultConfigLocalGateway implements ConfigLocalGateway {
 
   async clearPostPrefix(): Promise<void> {
     await this.storage.remove(['postPrefix'])
+  }
+
+  async getCopyToClipboardOnPost(): Promise<boolean> {
+    const { copyToClipboardOnPost } = await this.storage.get({
+      copyToClipboardOnPost: false,
+    })
+    return copyToClipboardOnPost
+  }
+
+  async saveCopyToClipboardOnPost(value: boolean): Promise<void> {
+    await this.storage.save({ copyToClipboardOnPost: value })
   }
 
   async saveSession(session: AtpSessionData): Promise<void> {

--- a/src/di/BackgroundComponent.ts
+++ b/src/di/BackgroundComponent.ts
@@ -41,6 +41,9 @@ export class DefaultBackgroundComponent implements BackgroundComponent {
           this.dataModule.clock(),
           this.platformModule.chromeDelegate(),
           this.dataModule.bskyRepository(this.platformModule.storageDelegate()),
+          this.dataModule.appPreferencesRepository(
+            this.platformModule.storageDelegate()
+          ),
           this.subCommands()
         ),
       (v) => (this._omniatp = v)

--- a/src/di/DataModule.ts
+++ b/src/di/DataModule.ts
@@ -11,6 +11,10 @@ import {
   DefaultPostTemplateRepository,
   PostTemplateRepository,
 } from '../data/PostTemplateRepository'
+import {
+  AppPreferencesRepository,
+  DefaultAppPreferencesRepository,
+} from '../data/AppPreferencesRepository'
 
 export interface DataModule {
   clock(): Clock
@@ -18,6 +22,9 @@ export interface DataModule {
   configLocalGateway(storage: ChromeStorageDelegate): ConfigLocalGateway
   bskyRepository(storage: ChromeStorageDelegate): BskyRepository
   postTemplateRepository(storage: ChromeStorageDelegate): PostTemplateRepository
+  appPreferencesRepository(
+    storage: ChromeStorageDelegate
+  ): AppPreferencesRepository
 }
 
 export class DefaultDataModule implements DataModule {
@@ -26,6 +33,7 @@ export class DefaultDataModule implements DataModule {
   private _configLocalGateway?: ConfigLocalGateway
   private _bskyRepository?: BskyRepository
   private _postTemplateRepository?: PostTemplateRepository
+  private _appPreferencesRepository?: AppPreferencesRepository
 
   clock(): Clock {
     return getOrCreate(
@@ -80,6 +88,17 @@ export class DefaultDataModule implements DataModule {
       this._postTemplateRepository,
       () => new DefaultPostTemplateRepository(this.configLocalGateway(storage)),
       (v) => (this._postTemplateRepository = v)
+    )
+  }
+
+  appPreferencesRepository(
+    storage: ChromeStorageDelegate
+  ): AppPreferencesRepository {
+    return getOrCreate(
+      this._appPreferencesRepository,
+      () =>
+        new DefaultAppPreferencesRepository(this.configLocalGateway(storage)),
+      (v) => (this._appPreferencesRepository = v)
     )
   }
 }

--- a/src/di/OptionsComponent.ts
+++ b/src/di/OptionsComponent.ts
@@ -1,5 +1,6 @@
 import { BskyRepository } from '../data/BskyRepository'
 import { PostTemplateRepository } from '../data/PostTemplateRepository'
+import { AppPreferencesRepository } from '../data/AppPreferencesRepository'
 import { ChromeDelegate } from '../platform/ChromeDelegate'
 import { DataModule } from './DataModule'
 import { PlatformModule } from './PlatformModule'
@@ -8,12 +9,14 @@ import { getOrCreate } from './helper'
 export interface OptionsComponent {
   bskyRepository(): BskyRepository
   postTemplateRepository(): PostTemplateRepository
+  appPreferencesRepository(): AppPreferencesRepository
   chromeDelegate(): ChromeDelegate
 }
 
 export class DefaultOptionsComponent implements OptionsComponent {
   private _bskyRepository?: BskyRepository
   private _postTemplateRepository?: PostTemplateRepository
+  private _appPreferencesRepository?: AppPreferencesRepository
 
   constructor(
     readonly dataModule: DataModule,
@@ -37,6 +40,17 @@ export class DefaultOptionsComponent implements OptionsComponent {
           this.platformModule.storageDelegate()
         ),
       (v) => (this._postTemplateRepository = v)
+    )
+  }
+
+  appPreferencesRepository(): AppPreferencesRepository {
+    return getOrCreate(
+      this._appPreferencesRepository,
+      () =>
+        this.dataModule.appPreferencesRepository(
+          this.platformModule.storageDelegate()
+        ),
+      (v) => (this._appPreferencesRepository = v)
     )
   }
 

--- a/src/entrypoints/offscreen/index.html
+++ b/src/entrypoints/offscreen/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>OmniATP Offscreen</title>
+  </head>
+  <body>
+    <textarea id="clipboard-target"></textarea>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/entrypoints/offscreen/main.ts
+++ b/src/entrypoints/offscreen/main.ts
@@ -1,0 +1,47 @@
+import {
+  OFFSCREEN_CLIPBOARD_TARGET,
+  OffscreenClipboardMessage,
+} from '../../platform/offscreen-messages'
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  const msg = message as Partial<OffscreenClipboardMessage>
+  if (msg?.target !== OFFSCREEN_CLIPBOARD_TARGET) {
+    return false
+  }
+
+  if (msg.type === 'copy' && typeof msg.text === 'string') {
+    void writeToClipboard(msg.text)
+      .then(() => sendResponse({ ok: true }))
+      .catch((e: unknown) => {
+        const message = e instanceof Error ? e.message : String(e)
+        sendResponse({ ok: false, error: message })
+      })
+      // Close so the next copy runs against a fresh document; reusing the
+      // page makes execCommand('copy') silently fail on later invocations.
+      .finally(() => window.close())
+    return true
+  }
+
+  return false
+})
+
+// Offscreen documents are never focused, so navigator.clipboard.writeText
+// throws "Document is not focused". The textarea + execCommand pattern is the
+// path Chrome officially supports for offscreen clipboard writes.
+async function writeToClipboard(text: string): Promise<void> {
+  const textarea =
+    document.querySelector<HTMLTextAreaElement>('#clipboard-target')
+  if (!textarea) {
+    throw new Error('Clipboard textarea element is missing')
+  }
+
+  textarea.value = text
+  textarea.focus()
+  textarea.select()
+
+  const ok = document.execCommand('copy')
+  textarea.value = ''
+  if (!ok) {
+    throw new Error('document.execCommand("copy") returned false')
+  }
+}

--- a/src/platform/ChromeDelegate.ts
+++ b/src/platform/ChromeDelegate.ts
@@ -1,3 +1,8 @@
+import {
+  OFFSCREEN_CLIPBOARD_TARGET,
+  OffscreenClipboardMessage,
+  OffscreenClipboardResponse,
+} from './offscreen-messages'
 import { Chrome, escapeText } from '../utils'
 
 export interface ChromeDelegate {
@@ -8,6 +13,7 @@ export interface ChromeDelegate {
   openNewTab(url: string, active: boolean): void
   openOptionsPage(): void
   createNotification(iconUrl: string, title: string, message: string): void
+  copyToClipboard(text: string): Promise<void>
   storeUrl(): string
   onStorageChanged(
     listener: (changes: { [key: string]: chrome.storage.StorageChange }) => void
@@ -68,6 +74,40 @@ export class DefaultChromeDelegate implements ChromeDelegate {
         }, 3000)
       }
     )
+  }
+
+  async copyToClipboard(text: string): Promise<void> {
+    await this.ensureOffscreenDocument()
+
+    const message: OffscreenClipboardMessage = {
+      target: OFFSCREEN_CLIPBOARD_TARGET,
+      type: 'copy',
+      text,
+    }
+    const response = (await this.chrome.runtime.sendMessage(message)) as
+      | OffscreenClipboardResponse
+      | undefined
+
+    if (!response?.ok) {
+      throw new Error(response?.error ?? 'Clipboard copy failed')
+    }
+  }
+
+  private async ensureOffscreenDocument(): Promise<void> {
+    const offscreen = this.chrome.offscreen
+    if (!offscreen) {
+      throw new Error('chrome.offscreen API is not available')
+    }
+
+    if (await offscreen.hasDocument()) {
+      return
+    }
+
+    await offscreen.createDocument({
+      url: this.chrome.runtime.getURL('offscreen.html'),
+      reasons: [offscreen.Reason.CLIPBOARD],
+      justification: 'Write a posted Bluesky message to the clipboard.',
+    })
   }
 
   storeUrl(): string {

--- a/src/platform/ChromeStorageDelegate.ts
+++ b/src/platform/ChromeStorageDelegate.ts
@@ -3,7 +3,7 @@ type ChromeStorage =
   | typeof chrome.storage.session
   | typeof chrome.storage.sync
 
-type StorageValueType = string | number | object | null
+type StorageValueType = string | number | boolean | object | null
 
 type StorageChangeEvent = chrome.storage.StorageChange
 

--- a/src/platform/offscreen-messages.ts
+++ b/src/platform/offscreen-messages.ts
@@ -1,0 +1,12 @@
+export const OFFSCREEN_CLIPBOARD_TARGET = 'omniatp.offscreen.clipboard'
+
+export interface OffscreenClipboardMessage {
+  target: typeof OFFSCREEN_CLIPBOARD_TARGET
+  type: 'copy'
+  text: string
+}
+
+export interface OffscreenClipboardResponse {
+  ok: boolean
+  error?: string
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -28,7 +28,13 @@ export default defineConfig({
       omnibox: {
         keyword: isDev ? 'atd' : 'at',
       },
-      permissions: ['tabs', 'notifications', 'storage'],
+      permissions: [
+        'tabs',
+        'notifications',
+        'storage',
+        'offscreen',
+        'clipboardWrite',
+      ],
       host_permissions: [],
       content_security_policy: {
         extension_pages: "script-src 'self'; object-src 'self';",


### PR DESCRIPTION
## Summary
- Add an opt-in **Copy to clipboard on post** toggle in the options page (default OFF). When enabled, the posted Bluesky message text is copied to the clipboard after a successful post.
- Implement clipboard write from the service worker via a Chrome offscreen document (`src/entrypoints/offscreen/`). Uses the `<textarea> + document.execCommand('copy')` pattern because `navigator.clipboard.writeText` rejects with "Document is not focused" inside offscreen documents.
- Add `offscreen` and `clipboardWrite` permissions. Both are required — the CLIPBOARD reason alone is not enough for execCommand to succeed.
- New `AppPreferencesRepository` follows the existing Gateway → Repository → consumer layering for persisting the toggle. `CLAUDE.md` updated with the layering rule and the offscreen-clipboard gotchas.

## Test plan
- [ ] `pnpm compile` passes
- [ ] `pnpm build` produces `.output/chrome-mv3/offscreen.html` and the manifest contains `offscreen` + `clipboardWrite` permissions
- [ ] Load the unpacked extension; sign in via the options page
- [ ] Toggle **Copy to clipboard on post** ON in options
- [ ] Post via the omnibox (`at <message>` or `atd <message>` in dev) and confirm the message text lands in the clipboard
- [ ] Toggle OFF and confirm clipboard is no longer overwritten on post
- [ ] Confirm a clipboard-copy failure does not block the post itself (only logs to console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)