### PR TITLE
chore: split renovate groups by manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,29 @@
 {
-  "extends": ["config:recommended", ":pinDependencies", ":pinDevDependencies"],
+  "extends": ["config:best-practices", ":pinDependencies", ":pinDevDependencies"],
   "reviewers": ["yshrsmz"],
   "lockFileMaintenance": {
     "enabled": true
   },
   "dependencyDashboard": true,
-  "prConcurrentLimit": 1,
+  "prConcurrentLimit": 3,
   "packageRules": [
     {
+      "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "matchPackageNames": ["*"]
+      "groupName": "npm non-major dependencies",
+      "groupSlug": "npm-minor-patch"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions non-major dependencies",
+      "groupSlug": "github-actions-minor-patch"
+    },
+    {
+      "matchManagers": ["mise"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "mise non-major dependencies",
+      "groupSlug": "mise-minor-patch"
     },
     {
       "matchPackageNames": ["vite", "@vitejs{/,}**"],


### PR DESCRIPTION
## Summary
- `extends` を `config:recommended` から `config:best-practices` に変更
- minor/patch のグループを `matchManagers` で npm / github-actions / mise に分割
- `prConcurrentLimit` を 1 → 3 に引き上げ

## Test plan
- [ ] Renovate の Dependency Dashboard で 3 つのマネージャー別グループが期待通り作成されること
- [ ] 既存の vitejs グループが従来どおり別 PR として開かれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)