### PR TITLE
feat(share): rewrite Amazon URLs with associate tag

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,12 +7,15 @@ import { AppBskyActorDefs } from '@atproto/api'
 import { AuthProgress } from './data/model/AuthProgress'
 import { AppConfig, BskyConfig } from './Configs'
 import { PostTemplate } from './data/model/PostTemplate'
+import { AmazonAssociate } from './data/model/AmazonAssociate'
 import { LoginCredential } from './data/model/LoginCredential'
 
 const component = createOptionsComponent(chrome)
 
 const _postTemplate = ref<PostTemplate>(PostTemplate.empty())
 const _copyToClipboardOnPost = ref<boolean>(false)
+const _amazonAssociate = ref<AmazonAssociate>(AmazonAssociate.empty())
+const amazonDomains = component.amazonAssociateRepository().getAmazonDomains()
 
 const service = BskyConfig.service
 const appVersion = component.chromeDelegate().appVersion()
@@ -41,6 +44,14 @@ const copyToClipboardOnPost = computed<boolean>({
   },
 })
 
+const amazonAssociate = computed<AmazonAssociate>({
+  get: () => _amazonAssociate.value,
+  set: (value) => {
+    _amazonAssociate.value = value
+    component.amazonAssociateRepository().save(value)
+  },
+})
+
 const handleSignIn = async (value: LoginCredential) => {
   authProgress.value = AuthProgress.IN_PROGRESS()
   try {
@@ -66,10 +77,11 @@ onMounted(async () => {
   const repo = component.bskyRepository()
   await repo.resumeSession()
 
-  const [p, template, copyOnPost] = await Promise.all([
+  const [p, template, copyOnPost, associate] = await Promise.all([
     repo.getProfile(),
     component.postTemplateRepository().get(),
     component.appPreferencesRepository().shouldCopyToClipboardOnPost(),
+    component.amazonAssociateRepository().get(),
   ])
 
   console.log('profile', p)
@@ -79,6 +91,7 @@ onMounted(async () => {
     : AuthProgress.UNAUTHORIZED()
   _postTemplate.value = template
   _copyToClipboardOnPost.value = copyOnPost
+  _amazonAssociate.value = associate
 })
 </script>
 
@@ -91,9 +104,11 @@ onMounted(async () => {
       <SettingsList
         v-model:post-template="postTemplate"
         v-model:copy-to-clipboard-on-post="copyToClipboardOnPost"
+        v-model:amazon-associate="amazonAssociate"
         v-model:auth-progress="authProgress"
         class="w-full"
         :service="service"
+        :amazon-domains="amazonDomains"
         :app-version="appVersion"
         :developer="developer"
         :store-url="storeUrl"

--- a/src/background/SubCommands.test.ts
+++ b/src/background/SubCommands.test.ts
@@ -3,6 +3,8 @@ import { Options, Share, Version } from './SubCommands'
 import { createFakeChromeDelegate } from '../test/FakeChromeDelegate'
 import { PostTemplateRepository } from '../data/PostTemplateRepository'
 import { PostTemplate } from '../data/model/PostTemplate'
+import { AmazonAssociateRepository } from '../data/AmazonAssociateRepository'
+import { AmazonAssociate } from '../data/model/AmazonAssociate'
 
 describe('Options sub-command', () => {
   const sub = new Options()
@@ -58,13 +60,23 @@ describe('Version sub-command', () => {
 })
 
 describe('Share sub-command', () => {
-  const buildShare = (prefix = 'NowBrowsing: ') => {
+  const buildShare = (
+    options: { prefix?: string; associate?: AmazonAssociate } = {}
+  ) => {
+    const { prefix = 'NowBrowsing: ', associate = AmazonAssociate.empty() } =
+      options
     const repo: PostTemplateRepository = {
       get: vi.fn(async () => new PostTemplate(prefix)),
       save: vi.fn(),
       clear: vi.fn(),
     }
-    return { share: new Share(repo), repo }
+    const associateRepo: AmazonAssociateRepository = {
+      get: vi.fn(async () => associate),
+      save: vi.fn(),
+      clear: vi.fn(),
+      getAmazonDomains: vi.fn(() => AmazonAssociate.AMAZON_DOMAINS),
+    }
+    return { share: new Share(repo, associateRepo), repo, associateRepo }
   }
 
   describe('test()', () => {
@@ -103,7 +115,7 @@ describe('Share sub-command', () => {
     })
 
     it('uses the post template prefix when no user input is provided', async () => {
-      const { share } = buildShare('PRE: ')
+      const { share } = buildShare({ prefix: 'PRE: ' })
       const chrome = createFakeChromeDelegate({
         currentPage: async () =>
           ({
@@ -125,7 +137,7 @@ describe('Share sub-command', () => {
     })
 
     it('uses the user input as the lead line when provided', async () => {
-      const { share } = buildShare('PRE: ')
+      const { share } = buildShare({ prefix: 'PRE: ' })
       const chrome = createFakeChromeDelegate({
         currentPage: async () =>
           ({
@@ -138,6 +150,58 @@ describe('Share sub-command', () => {
 
       expect(payload.message.startsWith('my comment\n')).toBe(true)
       expect(payload.message).not.toMatch(/^PRE: /)
+    })
+
+    it('rewrites Amazon product URLs in both the message and the link meta', async () => {
+      const { share } = buildShare({
+        associate: new AmazonAssociate('www.amazon.co.jp', 'my-tag-22'),
+      })
+      const chrome = createFakeChromeDelegate({
+        currentPage: async () =>
+          ({
+            url: 'https://www.amazon.co.jp/some-name/dp/B0DXXXXXX1/ref=foo',
+            title: 'Some Product',
+          }) as chrome.tabs.Tab,
+      })
+
+      const payload = await share.buildShareMessage(':share', chrome)
+
+      const expected = 'https://www.amazon.co.jp/dp/B0DXXXXXX1/?tag=my-tag-22'
+      expect(payload.message).toContain(expected)
+      expect(payload.meta?.uri).toBe(expected)
+    })
+
+    it('leaves the URL untouched when the configured Amazon domain differs', async () => {
+      const { share } = buildShare({
+        associate: new AmazonAssociate('www.amazon.co.jp', 'my-tag-22'),
+      })
+      const chrome = createFakeChromeDelegate({
+        currentPage: async () =>
+          ({
+            url: 'https://www.amazon.com/dp/B0DXXXXXX1/',
+            title: 'Some Product',
+          }) as chrome.tabs.Tab,
+      })
+
+      const payload = await share.buildShareMessage(':share', chrome)
+
+      expect(payload.message).toContain('https://www.amazon.com/dp/B0DXXXXXX1/')
+      expect(payload.meta?.uri).toBe('https://www.amazon.com/dp/B0DXXXXXX1/')
+    })
+
+    it('leaves the URL untouched when no associate is configured', async () => {
+      const { share } = buildShare()
+      const chrome = createFakeChromeDelegate({
+        currentPage: async () =>
+          ({
+            url: 'https://www.amazon.co.jp/dp/B0DXXXXXX1/',
+            title: 'Some Product',
+          }) as chrome.tabs.Tab,
+      })
+
+      const payload = await share.buildShareMessage(':share', chrome)
+
+      expect(payload.meta?.uri).toBe('https://www.amazon.co.jp/dp/B0DXXXXXX1/')
     })
   })
 
@@ -158,7 +222,7 @@ describe('Share sub-command', () => {
 
   describe('handleEnterEvent', () => {
     it('returns the same payload as buildShareMessage', async () => {
-      const { share } = buildShare('PRE: ')
+      const { share } = buildShare({ prefix: 'PRE: ' })
       const chrome = createFakeChromeDelegate({
         currentPage: async () =>
           ({

--- a/src/background/SubCommands.ts
+++ b/src/background/SubCommands.ts
@@ -1,4 +1,5 @@
 import { PostTemplateRepository } from '../data/PostTemplateRepository'
+import { AmazonAssociateRepository } from '../data/AmazonAssociateRepository'
 import { LinkMeta } from '../data/model/LinkMeta'
 import { ChromeDelegate } from '../platform/ChromeDelegate'
 
@@ -72,7 +73,8 @@ export class Share implements SubCommand {
   description = 'Share url to twitter'
 
   constructor(
-    private readonly postTemplateRepository: PostTemplateRepository
+    private readonly postTemplateRepository: PostTemplateRepository,
+    private readonly amazonAssociateRepository: AmazonAssociateRepository
   ) {}
 
   test(command: string) {
@@ -93,20 +95,20 @@ export class Share implements SubCommand {
     chrome: ChromeDelegate
   ): Promise<Payload> {
     const currentPage = await chrome.currentPage()
-    const template = await this.postTemplateRepository.get()
+    const [template, associate] = await Promise.all([
+      this.postTemplateRepository.get(),
+      this.amazonAssociateRepository.get(),
+    ])
 
     let message = 'unable to share this page'
     let meta: LinkMeta | undefined = undefined
     if (currentPage && currentPage.url && currentPage.title) {
       const userInput = this.extractUserInput(command)
+      const url = associate.buildAssociateUrlOrReturnAsIs(currentPage.url)
 
-      message = template.buildPost(
-        userInput ?? '',
-        currentPage.title,
-        currentPage.url
-      )
+      message = template.buildPost(userInput ?? '', currentPage.title, url)
       meta = {
-        uri: currentPage.url,
+        uri: url,
         title: currentPage.title,
         description: '',
       }

--- a/src/components/SettingsList/AmazonAssociateIdItem.vue
+++ b/src/components/SettingsList/AmazonAssociateIdItem.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import SettingsListItem from './SettingsListItem.vue'
+import TextInputDialog from '../TextInputDialog.vue'
+
+const props = defineProps<{ associateId: string }>()
+
+const emit = defineEmits<{
+  (event: 'update:associateId', value: string): void
+}>()
+
+const showDialogRef = ref(false)
+
+const associateIdRef = computed({
+  get: () => props.associateId,
+  set: (value) => emit('update:associateId', value),
+})
+
+const handleClick = () => {
+  showDialogRef.value = true
+}
+</script>
+
+<template>
+  <SettingsListItem as="a" href="#" @click.prevent="handleClick">
+    <p>Amazon Associate ID</p>
+    <template #subtext>{{ associateId || '(not set)' }}</template>
+    <TextInputDialog
+      v-model:show="showDialogRef"
+      v-model:text="associateIdRef"
+      type="text"
+      name="amazonAssociateId"
+      title="Edit Amazon Associate ID"
+      label="Associate ID"
+      placeholder="ex. xxxxxxxx-22"
+    />
+  </SettingsListItem>
+</template>

--- a/src/components/SettingsList/AmazonDomainItem.vue
+++ b/src/components/SettingsList/AmazonDomainItem.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from '@headlessui/vue'
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/vue/20/solid'
+import { computed } from 'vue'
+import SettingsListItem from './SettingsListItem.vue'
+
+const PLACEHOLDER = 'Select your Amazon domain'
+
+const props = defineProps<{
+  domain: string
+  amazonDomains: readonly string[]
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:domain', value: string): void
+}>()
+
+const selected = computed<string>({
+  get: () => props.domain || PLACEHOLDER,
+  set: (value) => emit('update:domain', value === PLACEHOLDER ? '' : value),
+})
+
+const options = computed(() => [PLACEHOLDER, ...props.amazonDomains])
+</script>
+
+<template>
+  <SettingsListItem>
+    <p>Amazon Domain</p>
+    <template #subtext>
+      <Listbox v-model="selected" class="mt-1 w-72">
+        <div class="relative">
+          <ListboxButton
+            class="relative w-full cursor-default rounded-md bg-white py-2 pl-3 pr-10 text-left text-gray-900 shadow ring-1 ring-inset ring-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            <span class="block truncate">{{ selected }}</span>
+            <span
+              class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2"
+            >
+              <ChevronUpDownIcon
+                class="h-5 w-5 text-gray-400"
+                aria-hidden="true"
+              />
+            </span>
+          </ListboxButton>
+          <transition
+            leave-active-class="transition duration-100 ease-in"
+            leave-from-class="opacity-100"
+            leave-to-class="opacity-0"
+          >
+            <ListboxOptions
+              class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none"
+            >
+              <ListboxOption
+                v-for="option in options"
+                v-slot="{ active, selected: isSelected }"
+                :key="option"
+                :value="option"
+                as="template"
+              >
+                <li
+                  :class="[
+                    active ? 'bg-blue-100 text-blue-900' : 'text-gray-900',
+                    'relative cursor-default select-none py-2 pl-10 pr-4',
+                  ]"
+                >
+                  <span
+                    :class="[
+                      isSelected ? 'font-medium' : 'font-normal',
+                      'block truncate',
+                    ]"
+                    >{{ option }}</span
+                  >
+                  <span
+                    v-if="isSelected"
+                    class="absolute inset-y-0 left-0 flex items-center pl-3 text-blue-600"
+                  >
+                    <CheckIcon class="h-5 w-5" aria-hidden="true" />
+                  </span>
+                </li>
+              </ListboxOption>
+            </ListboxOptions>
+          </transition>
+        </div>
+      </Listbox>
+    </template>
+  </SettingsListItem>
+</template>

--- a/src/components/SettingsList/SettingsList.vue
+++ b/src/components/SettingsList/SettingsList.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { PostTemplate } from '../../data/model/PostTemplate'
+import { AmazonAssociate } from '../../data/model/AmazonAssociate'
 import AuthItem from './AuthItem.vue'
 import PostPrefixItem from './PostPrefixItem.vue'
 import CopyToClipboardItem from './CopyToClipboardItem.vue'
+import AmazonDomainItem from './AmazonDomainItem.vue'
+import AmazonAssociateIdItem from './AmazonAssociateIdItem.vue'
 import SettingsListHeader from './SettingsListHeader.vue'
 import { AppBskyActorDefs } from '@atproto/api'
 import SettingsListItem from './SettingsListItem.vue'
@@ -17,6 +20,8 @@ const props = defineProps<{
   profile?: AppBskyActorDefs.ProfileViewDetailed
   postTemplate: PostTemplate
   copyToClipboardOnPost: boolean
+  amazonAssociate: AmazonAssociate
+  amazonDomains: readonly string[]
   appVersion: string
   developer: Developer
   storeUrl: string
@@ -28,6 +33,7 @@ const emit = defineEmits<{
   (event: 'signout'): void
   (event: 'update:postTemplate', value: PostTemplate): void
   (event: 'update:copyToClipboardOnPost', value: boolean): void
+  (event: 'update:amazonAssociate', value: AmazonAssociate): void
   (event: 'update:authProgress', value: AuthProgress): void
 }>()
 
@@ -43,6 +49,20 @@ const handleUpdatePrefix = (prefix: string) => {
 
 const handleUpdateCopyToClipboard = (value: boolean) => {
   emit('update:copyToClipboardOnPost', value)
+}
+
+const handleUpdateAmazonDomain = (domain: string) => {
+  emit(
+    'update:amazonAssociate',
+    new AmazonAssociate(domain, props.amazonAssociate.associateId)
+  )
+}
+
+const handleUpdateAmazonAssociateId = (id: string) => {
+  emit(
+    'update:amazonAssociate',
+    new AmazonAssociate(props.amazonAssociate.domain, id)
+  )
 }
 </script>
 
@@ -66,6 +86,16 @@ const handleUpdateCopyToClipboard = (value: boolean) => {
       <CopyToClipboardItem
         :enabled="copyToClipboardOnPost"
         @update:enabled="handleUpdateCopyToClipboard"
+      />
+      <SettingsListHeader title="Amazon Associate" />
+      <AmazonDomainItem
+        :domain="amazonAssociate.domain"
+        :amazon-domains="amazonDomains"
+        @update:domain="handleUpdateAmazonDomain"
+      />
+      <AmazonAssociateIdItem
+        :associate-id="amazonAssociate.associateId"
+        @update:associate-id="handleUpdateAmazonAssociateId"
       />
       <SettingsListHeader title="Others" />
       <SettingsListItem class="!border-t-0">

--- a/src/data/AmazonAssociateRepository.test.ts
+++ b/src/data/AmazonAssociateRepository.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { DefaultAmazonAssociateRepository } from './AmazonAssociateRepository'
+import { DefaultConfigLocalGateway } from './ConfigLocalGateway'
+import { InMemoryStorageDelegate } from '../test/InMemoryStorageDelegate'
+import { AmazonAssociate } from './model/AmazonAssociate'
+import { noopLogger } from '../Logger'
+
+describe('DefaultAmazonAssociateRepository', () => {
+  const buildRepo = () => {
+    const storage = new InMemoryStorageDelegate()
+    const gateway = new DefaultConfigLocalGateway(storage, noopLogger)
+    const repo = new DefaultAmazonAssociateRepository(gateway)
+    return { storage, gateway, repo }
+  }
+
+  it('returns an empty AmazonAssociate when nothing is saved', async () => {
+    const { repo } = buildRepo()
+    const value = await repo.get()
+    expect(value.domain).toBe('')
+    expect(value.associateId).toBe('')
+    expect(value.isEnabled()).toBe(false)
+  })
+
+  it('round-trips a saved value', async () => {
+    const { repo } = buildRepo()
+    await repo.save(new AmazonAssociate('www.amazon.co.jp', 'my-tag-22'))
+    const loaded = await repo.get()
+    expect(loaded.domain).toBe('www.amazon.co.jp')
+    expect(loaded.associateId).toBe('my-tag-22')
+    expect(loaded.isEnabled()).toBe(true)
+  })
+
+  it('clear() reverts to empty', async () => {
+    const { repo } = buildRepo()
+    await repo.save(new AmazonAssociate('www.amazon.co.jp', 'my-tag-22'))
+    await repo.clear()
+    const loaded = await repo.get()
+    expect(loaded.domain).toBe('')
+    expect(loaded.associateId).toBe('')
+  })
+
+  it('exposes the supported Amazon domains', () => {
+    const { repo } = buildRepo()
+    expect(repo.getAmazonDomains()).toBe(AmazonAssociate.AMAZON_DOMAINS)
+    expect(repo.getAmazonDomains().length).toBe(17)
+  })
+})

--- a/src/data/AmazonAssociateRepository.ts
+++ b/src/data/AmazonAssociateRepository.ts
@@ -1,0 +1,33 @@
+import { ConfigLocalGateway } from './ConfigLocalGateway'
+import { AmazonAssociate } from './model/AmazonAssociate'
+
+export interface AmazonAssociateRepository {
+  get(): Promise<AmazonAssociate>
+  save(value: AmazonAssociate): Promise<void>
+  clear(): Promise<void>
+  getAmazonDomains(): readonly string[]
+}
+
+export class DefaultAmazonAssociateRepository implements AmazonAssociateRepository {
+  constructor(readonly localGateway: ConfigLocalGateway) {}
+
+  async get(): Promise<AmazonAssociate> {
+    const { domain, associateId } = await this.localGateway.getAmazonAssociate()
+    return new AmazonAssociate(domain, associateId)
+  }
+
+  async save(value: AmazonAssociate): Promise<void> {
+    await this.localGateway.saveAmazonAssociate({
+      domain: value.domain,
+      associateId: value.associateId,
+    })
+  }
+
+  async clear(): Promise<void> {
+    await this.localGateway.clearAmazonAssociate()
+  }
+
+  getAmazonDomains(): readonly string[] {
+    return AmazonAssociate.AMAZON_DOMAINS
+  }
+}

--- a/src/data/ConfigLocalGateway.test.ts
+++ b/src/data/ConfigLocalGateway.test.ts
@@ -50,6 +50,41 @@ describe('DefaultConfigLocalGateway', () => {
     })
   })
 
+  describe('amazon associate', () => {
+    it('returns empty strings by default', async () => {
+      const gateway = buildGateway()
+      expect(await gateway.getAmazonAssociate()).toEqual({
+        domain: '',
+        associateId: '',
+      })
+    })
+
+    it('round-trips the saved value', async () => {
+      const gateway = buildGateway()
+      await gateway.saveAmazonAssociate({
+        domain: 'www.amazon.co.jp',
+        associateId: 'my-tag-22',
+      })
+      expect(await gateway.getAmazonAssociate()).toEqual({
+        domain: 'www.amazon.co.jp',
+        associateId: 'my-tag-22',
+      })
+    })
+
+    it('clears both keys', async () => {
+      const gateway = buildGateway()
+      await gateway.saveAmazonAssociate({
+        domain: 'www.amazon.co.jp',
+        associateId: 'my-tag-22',
+      })
+      await gateway.clearAmazonAssociate()
+      expect(await gateway.getAmazonAssociate()).toEqual({
+        domain: '',
+        associateId: '',
+      })
+    })
+  })
+
   describe('session', () => {
     it('returns undefined when no session is saved', async () => {
       const gateway = buildGateway()

--- a/src/data/ConfigLocalGateway.ts
+++ b/src/data/ConfigLocalGateway.ts
@@ -10,6 +10,13 @@ export interface ConfigLocalGateway {
   shouldCopyToClipboardOnPost(): Promise<boolean>
   saveCopyToClipboardOnPost(value: boolean): Promise<void>
 
+  getAmazonAssociate(): Promise<{ domain: string; associateId: string }>
+  saveAmazonAssociate(value: {
+    domain: string
+    associateId: string
+  }): Promise<void>
+  clearAmazonAssociate(): Promise<void>
+
   saveSession(session: AtpSessionData): Promise<void>
   getSession(): Promise<AtpSessionData | undefined>
   clearSession(): Promise<void>
@@ -48,6 +55,33 @@ export class DefaultConfigLocalGateway implements ConfigLocalGateway {
 
   async saveCopyToClipboardOnPost(value: boolean): Promise<void> {
     await this.storage.save({ copyToClipboardOnPost: value })
+  }
+
+  async getAmazonAssociate(): Promise<{
+    domain: string
+    associateId: string
+  }> {
+    const { amazonAssociateDomain, amazonAssociateId } = await this.storage.get(
+      {
+        amazonAssociateDomain: '',
+        amazonAssociateId: '',
+      }
+    )
+    return { domain: amazonAssociateDomain, associateId: amazonAssociateId }
+  }
+
+  async saveAmazonAssociate(value: {
+    domain: string
+    associateId: string
+  }): Promise<void> {
+    await this.storage.save({
+      amazonAssociateDomain: value.domain,
+      amazonAssociateId: value.associateId,
+    })
+  }
+
+  async clearAmazonAssociate(): Promise<void> {
+    await this.storage.remove(['amazonAssociateDomain', 'amazonAssociateId'])
   }
 
   async saveSession(session: AtpSessionData): Promise<void> {

--- a/src/data/model/AmazonAssociate.test.ts
+++ b/src/data/model/AmazonAssociate.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { AmazonAssociate } from './AmazonAssociate'
+
+describe('AmazonAssociate', () => {
+  describe('isAmazonDomain', () => {
+    it('returns true for known regional domains', () => {
+      expect(AmazonAssociate.isAmazonDomain('www.amazon.co.jp')).toBe(true)
+      expect(AmazonAssociate.isAmazonDomain('www.amazon.com')).toBe(true)
+      expect(AmazonAssociate.isAmazonDomain('www.amazon.de')).toBe(true)
+    })
+
+    it('returns false for non-Amazon domains', () => {
+      expect(AmazonAssociate.isAmazonDomain('example.com')).toBe(false)
+      expect(AmazonAssociate.isAmazonDomain('amazon.co.jp')).toBe(false)
+    })
+  })
+
+  describe('isEnabled', () => {
+    it('is false when associateId is empty', () => {
+      expect(new AmazonAssociate('www.amazon.co.jp', '').isEnabled()).toBe(
+        false
+      )
+    })
+
+    it('is false when domain is not in the supported list', () => {
+      expect(new AmazonAssociate('example.com', 'tag-22').isEnabled()).toBe(
+        false
+      )
+    })
+
+    it('is true when both domain and associateId are valid', () => {
+      expect(
+        new AmazonAssociate('www.amazon.co.jp', 'tag-22').isEnabled()
+      ).toBe(true)
+    })
+  })
+
+  describe('buildAssociateUrlOrReturnAsIs', () => {
+    const associate = new AmazonAssociate('www.amazon.co.jp', 'my-tag-22')
+
+    it('rewrites URLs to /dp/<ASIN>/?tag=<id> when domain matches', () => {
+      const input =
+        'https://www.amazon.co.jp/some-product-name/dp/B0DXXXXXX1/ref=foo?tag=other-22'
+      expect(associate.buildAssociateUrlOrReturnAsIs(input)).toBe(
+        'https://www.amazon.co.jp/dp/B0DXXXXXX1/?tag=my-tag-22'
+      )
+    })
+
+    it('rewrites /gp/product/<ASIN>/ paths', () => {
+      const input = 'https://www.amazon.co.jp/gp/product/0123456789/'
+      expect(associate.buildAssociateUrlOrReturnAsIs(input)).toBe(
+        'https://www.amazon.co.jp/dp/0123456789/?tag=my-tag-22'
+      )
+    })
+
+    it('preserves the original string (including missing trailing slash) when not rewriting', () => {
+      const input = 'https://example.com'
+      expect(associate.buildAssociateUrlOrReturnAsIs(input)).toBe(input)
+    })
+
+    it('returns the URL unchanged when associateId is empty', () => {
+      const empty = new AmazonAssociate('www.amazon.co.jp', '')
+      const input = 'https://www.amazon.co.jp/dp/B0DXXXXXX1/'
+      expect(empty.buildAssociateUrlOrReturnAsIs(input)).toBe(input)
+    })
+
+    it('returns the URL unchanged when the page domain differs from the configured one', () => {
+      const input = 'https://www.amazon.com/dp/B0DXXXXXX1/'
+      expect(associate.buildAssociateUrlOrReturnAsIs(input)).toBe(input)
+    })
+
+    it('returns the URL unchanged for a non-Amazon URL', () => {
+      const input = 'https://example.com/path?foo=bar'
+      expect(associate.buildAssociateUrlOrReturnAsIs(input)).toBe(input)
+    })
+
+    it('returns the URL unchanged for an Amazon page without an ASIN', () => {
+      const input = 'https://www.amazon.co.jp/gp/help/customer/display'
+      expect(associate.buildAssociateUrlOrReturnAsIs(input)).toBe(input)
+    })
+  })
+
+  describe('AMAZON_DOMAINS', () => {
+    it('lists 17 supported regional domains', () => {
+      expect(AmazonAssociate.AMAZON_DOMAINS.length).toBe(17)
+    })
+
+    it('includes the major regional domains', () => {
+      expect(AmazonAssociate.AMAZON_DOMAINS).toContain('www.amazon.co.jp')
+      expect(AmazonAssociate.AMAZON_DOMAINS).toContain('www.amazon.com')
+      expect(AmazonAssociate.AMAZON_DOMAINS).toContain('www.amazon.co.uk')
+      expect(AmazonAssociate.AMAZON_DOMAINS).toContain('www.amazon.de')
+    })
+  })
+
+  describe('empty()', () => {
+    it('returns an instance with empty domain and id', () => {
+      const empty = AmazonAssociate.empty()
+      expect(empty.domain).toBe('')
+      expect(empty.associateId).toBe('')
+      expect(empty.isEnabled()).toBe(false)
+    })
+  })
+})

--- a/src/data/model/AmazonAssociate.ts
+++ b/src/data/model/AmazonAssociate.ts
@@ -1,0 +1,54 @@
+export class AmazonAssociate {
+  constructor(
+    readonly domain: string,
+    readonly associateId: string
+  ) {}
+
+  isEnabled(): boolean {
+    return (
+      this.associateId !== '' && AmazonAssociate.isAmazonDomain(this.domain)
+    )
+  }
+
+  buildAssociateUrlOrReturnAsIs(rawUrl: string): string {
+    if (!this.isEnabled()) return rawUrl
+
+    const url = new URL(rawUrl)
+    if (url.hostname !== this.domain) return rawUrl
+
+    const match = url.pathname.match(AmazonAssociate.PRODUCT_ID_REGEXP)
+    if (!match) return rawUrl
+
+    return `https://${url.hostname}/dp/${match[1]}/?tag=${this.associateId}`
+  }
+
+  static isAmazonDomain(domain: string): boolean {
+    return AmazonAssociate.AMAZON_DOMAINS.indexOf(domain) >= 0
+  }
+
+  static empty(): AmazonAssociate {
+    return new AmazonAssociate('', '')
+  }
+
+  private static PRODUCT_ID_REGEXP = /[^0-9A-Z]([B0-9][0-9A-Z]{9})([^0-9A-Z]|$)/
+
+  static readonly AMAZON_DOMAINS = [
+    'www.amazon.ae',
+    'www.amazon.ca',
+    'www.amazon.cn',
+    'www.amazon.co.jp',
+    'www.amazon.co.uk',
+    'www.amazon.com',
+    'www.amazon.com.au',
+    'www.amazon.com.br',
+    'www.amazon.com.mx',
+    'www.amazon.com.tr',
+    'www.amazon.de',
+    'www.amazon.es',
+    'www.amazon.fr',
+    'www.amazon.in',
+    'www.amazon.it',
+    'www.amazon.nl',
+    'www.amazon.sg',
+  ]
+}

--- a/src/di/BackgroundComponent.ts
+++ b/src/di/BackgroundComponent.ts
@@ -26,6 +26,9 @@ export class DefaultBackgroundComponent implements BackgroundComponent {
         new Share(
           this.dataModule.postTemplateRepository(
             this.platformModule.storageDelegate()
+          ),
+          this.dataModule.amazonAssociateRepository(
+            this.platformModule.storageDelegate()
           )
         ),
       ],

--- a/src/di/DataModule.ts
+++ b/src/di/DataModule.ts
@@ -19,6 +19,10 @@ import {
   AppPreferencesRepository,
   DefaultAppPreferencesRepository,
 } from '../data/AppPreferencesRepository'
+import {
+  AmazonAssociateRepository,
+  DefaultAmazonAssociateRepository,
+} from '../data/AmazonAssociateRepository'
 import { Logger } from '../Logger'
 
 const defaultAtpAgentFactory: AtpAgentFactory = (options) =>
@@ -33,6 +37,9 @@ export interface DataModule {
   appPreferencesRepository(
     storage: ChromeStorageDelegate
   ): AppPreferencesRepository
+  amazonAssociateRepository(
+    storage: ChromeStorageDelegate
+  ): AmazonAssociateRepository
 }
 
 export class DefaultDataModule implements DataModule {
@@ -41,6 +48,7 @@ export class DefaultDataModule implements DataModule {
   private _bskyRepository?: BskyRepository
   private _postTemplateRepository?: PostTemplateRepository
   private _appPreferencesRepository?: AppPreferencesRepository
+  private _amazonAssociateRepository?: AmazonAssociateRepository
 
   constructor(private readonly logger: Logger) {}
 
@@ -99,6 +107,17 @@ export class DefaultDataModule implements DataModule {
       () =>
         new DefaultAppPreferencesRepository(this.configLocalGateway(storage)),
       (v) => (this._appPreferencesRepository = v)
+    )
+  }
+
+  amazonAssociateRepository(
+    storage: ChromeStorageDelegate
+  ): AmazonAssociateRepository {
+    return getOrCreate(
+      this._amazonAssociateRepository,
+      () =>
+        new DefaultAmazonAssociateRepository(this.configLocalGateway(storage)),
+      (v) => (this._amazonAssociateRepository = v)
     )
   }
 }

--- a/src/di/OptionsComponent.ts
+++ b/src/di/OptionsComponent.ts
@@ -1,6 +1,7 @@
 import { BskyRepository } from '../data/BskyRepository'
 import { PostTemplateRepository } from '../data/PostTemplateRepository'
 import { AppPreferencesRepository } from '../data/AppPreferencesRepository'
+import { AmazonAssociateRepository } from '../data/AmazonAssociateRepository'
 import { ChromeDelegate } from '../platform/ChromeDelegate'
 import { DataModule } from './DataModule'
 import { PlatformModule } from './PlatformModule'
@@ -10,6 +11,7 @@ export interface OptionsComponent {
   bskyRepository(): BskyRepository
   postTemplateRepository(): PostTemplateRepository
   appPreferencesRepository(): AppPreferencesRepository
+  amazonAssociateRepository(): AmazonAssociateRepository
   chromeDelegate(): ChromeDelegate
 }
 
@@ -17,6 +19,7 @@ export class DefaultOptionsComponent implements OptionsComponent {
   private _bskyRepository?: BskyRepository
   private _postTemplateRepository?: PostTemplateRepository
   private _appPreferencesRepository?: AppPreferencesRepository
+  private _amazonAssociateRepository?: AmazonAssociateRepository
 
   constructor(
     readonly dataModule: DataModule,
@@ -51,6 +54,17 @@ export class DefaultOptionsComponent implements OptionsComponent {
           this.platformModule.storageDelegate()
         ),
       (v) => (this._appPreferencesRepository = v)
+    )
+  }
+
+  amazonAssociateRepository(): AmazonAssociateRepository {
+    return getOrCreate(
+      this._amazonAssociateRepository,
+      () =>
+        this.dataModule.amazonAssociateRepository(
+          this.platformModule.storageDelegate()
+        ),
+      (v) => (this._amazonAssociateRepository = v)
     )
   }
 


### PR DESCRIPTION
## Summary

- Add an Amazon Associate setting (domain + ID) to the options page, ported from the sister project `omnitweety`
- During `:share`, rewrite the current page URL to `https://<domain>/dp/<ASIN>/?tag=<id>` when the page matches the configured Amazon storefront; both the post body and the link card embed (`meta.uri`) use the rewritten URL
- Non-matching URLs (different Amazon region, non-Amazon hosts, Amazon pages without an ASIN, or when the feature is unconfigured) pass through unchanged with the original string preserved

## Implementation notes

- New domain model `AmazonAssociate` (17 regional Amazon hostnames + ASIN regex) and a thin `AmazonAssociateRepository` over `ConfigLocalGateway`, wired through `DataModule` / `BackgroundComponent` / `OptionsComponent` per the existing DI pattern
- Storage uses two `chrome.storage.local` keys (`amazonAssociateDomain`, `amazonAssociateId`) read/written in a single batched call at the gateway boundary
- UI: a Headless UI Listbox for picking the domain and a `TextInputDialog`-backed text field for the associate ID, placed under a new "Amazon Associate" section in the settings list

## Test plan

- [x] `pnpm test` — 142 tests pass, including new coverage for the model (URL rewrite + passthrough cases), repository round-trip, gateway round-trip, and the `:share` sub-command
- [x] `pnpm compile` — type check passes
- [x] `pnpm lint:fix` — no findings
- [ ] Manual: load the unpacked dev build, set `www.amazon.co.jp` + a tag on the options page, open an Amazon JP product page, run `atd :share`, and confirm the suggestion + Bluesky link card both use the affiliate URL
- [ ] Manual: confirm domain mismatch (e.g. amazon.com page with JP setting), non-Amazon URLs, and an unset associate ID all leave the URL unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)