### PR TITLE
feat(options): show changelog in options page

### DIFF
--- a/.claude/rules/asking.md
+++ b/.claude/rules/asking.md
@@ -1,0 +1,17 @@
+# Asking the user questions
+
+When you need to ask the user a question — whether to clarify requirements, choose between approaches, or confirm a decision — use the **AskUserQuestion** tool by default. Do not embed questions inside a long prose answer.
+
+Why:
+
+- Structured questions render as selectable options in the UI, which is faster to answer than free-form prose.
+- It forces you to enumerate the options yourself instead of asking open-ended "what do you think?" questions that push synthesis back onto the user.
+- Multiple related questions can be batched into a single call (up to 4) and answered together, reducing round-trips.
+
+When to skip the tool and ask in plain text:
+
+- The question is purely conversational ("does that match what you remembered?", "anything else?").
+- You're confirming a one-line factual detail in passing inside a larger explanation.
+- The user explicitly said "just ask me directly" earlier in the session.
+
+Otherwise, default to AskUserQuestion. Each question should have 2-4 mutually-exclusive options with a short label and a one-line description; the UI auto-adds an "Other" escape hatch so do not include one yourself.

--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,37 @@
+# Comments
+
+## Exported declarations get a doc comment
+
+Top-level **exported** declarations — functions, constants, variables, classes, types, interfaces — should have a leading JSDoc-style comment (`/** … */`) describing what they are.
+
+```ts
+/**
+ * Parses a release-please CHANGELOG.md into structured releases.
+ */
+export const parseChangelog = (markdown: string): Changelog => { … }
+
+/**
+ * One bullet item under a release section.
+ */
+export interface ChangelogItem { … }
+```
+
+Why this rule overrides the "default to no comments" guidance:
+
+- Exports are the public surface of a module. Callers shouldn't have to read the body to understand intent.
+- A short doc comment shows up in IDE hovers / autocomplete and pays for itself.
+
+What the comment should say:
+
+- Lead with **what** the thing is, in one sentence. The implementation answers _how_; the comment answers _what / why_.
+- Mention non-obvious constraints (input format expectations, side effects, ownership of returned objects) when they exist.
+- Skip restating the type signature. `parseChangelog(markdown: string): Changelog` already says it takes a string and returns a `Changelog` — don't repeat that.
+
+What is **not** required:
+
+- Internal (non-exported) helpers in the same file. Keep them comment-free unless the _why_ is non-obvious (per CLAUDE.md).
+- `default export` of Vue SFCs / single-component files where the filename and `<script setup>` props already describe the component. A comment is welcome but not mandatory.
+- Re-exports that just forward another module's symbol — the original declaration carries the doc.
+- Test files (`*.test.ts`) — `describe`/`it` strings carry the documentation.
+
+If a comment would only restate the identifier name (`/** The user. */ export const user = …`), don't write it. Either say something useful or omit.

--- a/src/components/SettingsList/ChangelogDialog.test.ts
+++ b/src/components/SettingsList/ChangelogDialog.test.ts
@@ -72,4 +72,38 @@ describe('ChangelogDialog', () => {
     await closeButton.trigger('click')
     expect(wrapper.emitted('update:show')?.[0]).toEqual([false])
   })
+
+  it('renders inline code and bold markdown inside item descriptions', () => {
+    const changelog: Changelog = {
+      releases: [
+        {
+          version: '0.1.0',
+          versionUrl: undefined,
+          date: '2026-05-08',
+          sections: [
+            {
+              title: 'Features',
+              items: [
+                {
+                  scope: undefined,
+                  description:
+                    'use `Property<String>` and the **important** flag',
+                  links: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const wrapper = mountDialog(changelog)
+    const codeEl = wrapper.find('code')
+    expect(codeEl.exists()).toBe(true)
+    expect(codeEl.text()).toBe('Property<String>')
+    const boldEls = wrapper.findAll('strong')
+    const importantBold = boldEls.find((el) => el.text() === 'important')
+    expect(importantBold?.exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('`Property<String>`')
+    expect(wrapper.text()).not.toContain('**important**')
+  })
 })

--- a/src/components/SettingsList/ChangelogDialog.test.ts
+++ b/src/components/SettingsList/ChangelogDialog.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ChangelogDialog from './ChangelogDialog.vue'
+import type { Changelog } from '../../data/model/Changelog'
+import { headlessuiStubs } from '../../test/headlessui-stubs'
+
+const sampleChangelog: Changelog = {
+  releases: [
+    {
+      version: '0.0.4',
+      versionUrl: 'https://example.com/compare',
+      date: '2026-05-08',
+      sections: [
+        {
+          title: 'Features',
+          items: [
+            {
+              scope: 'share',
+              description: 'rewrite Amazon URLs with associate tag',
+              links: [
+                { text: '#92', url: 'https://example.com/i92' },
+                { text: '3ec4370', url: 'https://example.com/c3ec' },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+const mountDialog = (changelog: Changelog = sampleChangelog, show = true) =>
+  mount(ChangelogDialog, {
+    props: { show, changelog },
+    global: { stubs: headlessuiStubs },
+  })
+
+describe('ChangelogDialog', () => {
+  it('does not render content when show is false', () => {
+    const wrapper = mountDialog(sampleChangelog, false)
+    expect(wrapper.text()).not.toContain('Changelog')
+  })
+
+  it('renders the version, date and section title', () => {
+    const wrapper = mountDialog()
+    expect(wrapper.text()).toContain('0.0.4')
+    expect(wrapper.text()).toContain('2026-05-08')
+    expect(wrapper.text()).toContain('Features')
+  })
+
+  it('renders the item description, scope and links', () => {
+    const wrapper = mountDialog()
+    expect(wrapper.text()).toContain('share:')
+    expect(wrapper.text()).toContain('rewrite Amazon URLs with associate tag')
+    const anchors = wrapper.findAll('a')
+    const hrefs = anchors.map((a) => a.attributes('href'))
+    expect(hrefs).toContain('https://example.com/compare')
+    expect(hrefs).toContain('https://example.com/i92')
+    expect(hrefs).toContain('https://example.com/c3ec')
+  })
+
+  it('shows an empty-state message when there are no releases', () => {
+    const wrapper = mountDialog({ releases: [] })
+    expect(wrapper.text()).toContain('No releases yet.')
+  })
+
+  it('emits update:show=false when Close is clicked', async () => {
+    const wrapper = mountDialog()
+    const closeButton = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Close')!
+    await closeButton.trigger('click')
+    expect(wrapper.emitted('update:show')?.[0]).toEqual([false])
+  })
+})

--- a/src/components/SettingsList/ChangelogDialog.vue
+++ b/src/components/SettingsList/ChangelogDialog.vue
@@ -6,7 +6,7 @@ import {
   DialogPanel,
   DialogTitle,
 } from '@headlessui/vue'
-import type { Changelog } from '../../data/model/Changelog'
+import { parseInline, type Changelog } from '../../data/model/Changelog'
 
 defineProps<{
   show: boolean
@@ -114,9 +114,26 @@ const handleClose = () => {
                             <strong v-if="item.scope" class="font-semibold"
                               >{{ item.scope }}:</strong
                             >
-                            <span :class="{ 'ml-1': item.scope }">{{
-                              item.description
-                            }}</span>
+                            <span :class="{ 'ml-1': item.scope }">
+                              <template
+                                v-for="(token, tokenIndex) in parseInline(
+                                  item.description
+                                )"
+                                :key="`tok-${tokenIndex}`"
+                              >
+                                <code
+                                  v-if="token.type === 'code'"
+                                  class="rounded bg-gray-100 px-1 font-mono text-xs"
+                                  >{{ token.text }}</code
+                                >
+                                <strong
+                                  v-else-if="token.type === 'bold'"
+                                  class="font-semibold"
+                                  >{{ token.text }}</strong
+                                >
+                                <template v-else>{{ token.text }}</template>
+                              </template>
+                            </span>
                             <template
                               v-for="link in item.links"
                               :key="link.url"

--- a/src/components/SettingsList/ChangelogDialog.vue
+++ b/src/components/SettingsList/ChangelogDialog.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import {
+  TransitionRoot,
+  TransitionChild,
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+} from '@headlessui/vue'
+import type { Changelog } from '../../data/model/Changelog'
+
+defineProps<{
+  show: boolean
+  changelog: Changelog
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:show', value: boolean): void
+}>()
+
+const handleClose = () => {
+  emit('update:show', false)
+}
+</script>
+
+<template>
+  <TransitionRoot appear :show="show" as="template">
+    <Dialog
+      as="div"
+      class="ChangelogDialog relative z-10"
+      @close="emit('update:show', false)"
+    >
+      <TransitionChild
+        as="template"
+        enter="duration-300 ease-out"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="duration-200 ease-in"
+        leave-from="opacity-100"
+        leave-to="opacity-0"
+      >
+        <div class="fixed inset-0 bg-black bg-opacity-25" />
+      </TransitionChild>
+
+      <div class="fixed inset-0 overflow-y-auto">
+        <div
+          class="flex min-h-full items-center justify-center p-4 text-center"
+        >
+          <TransitionChild
+            as="template"
+            enter="duration-300 ease-out"
+            enter-from="opacity-0 scale-95"
+            enter-to="opacity-100 scale-100"
+            leave="duration-200 ease-in"
+            leave-from="opacity-100 scale-100"
+            leave-to="opacity-0 scale-95"
+          >
+            <DialogPanel
+              class="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white text-left align-middle shadow-xl transition-all flex flex-col max-h-[80vh]"
+            >
+              <DialogTitle
+                as="h3"
+                class="text-lg font-medium leading-6 text-gray-900 px-6 pt-6"
+              >
+                Changelog
+              </DialogTitle>
+              <div class="mt-4 px-6 overflow-y-auto flex-1">
+                <p
+                  v-if="changelog.releases.length === 0"
+                  class="text-sm text-gray-500"
+                >
+                  No releases yet.
+                </p>
+                <ul v-else class="space-y-6">
+                  <li
+                    v-for="release in changelog.releases"
+                    :key="release.version"
+                  >
+                    <h4 class="text-base font-semibold text-gray-900">
+                      <a
+                        v-if="release.versionUrl"
+                        :href="release.versionUrl"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-indigo-600 hover:underline"
+                      >
+                        {{ release.version }}
+                      </a>
+                      <span v-else>{{ release.version }}</span>
+                      <span
+                        v-if="release.date"
+                        class="ml-2 text-sm font-normal text-gray-500"
+                      >
+                        {{ release.date }}
+                      </span>
+                    </h4>
+                    <div
+                      v-for="section in release.sections"
+                      :key="section.title"
+                      class="mt-3"
+                    >
+                      <h5
+                        class="text-sm font-medium text-gray-700 uppercase tracking-wide"
+                      >
+                        {{ section.title }}
+                      </h5>
+                      <ul class="mt-1 space-y-1 text-sm text-gray-700">
+                        <li
+                          v-for="(item, index) in section.items"
+                          :key="`${section.title}-${index}`"
+                          class="flex"
+                        >
+                          <span class="mr-2 text-gray-400">•</span>
+                          <span class="flex-1">
+                            <strong v-if="item.scope" class="font-semibold"
+                              >{{ item.scope }}:</strong
+                            >
+                            <span :class="{ 'ml-1': item.scope }">{{
+                              item.description
+                            }}</span>
+                            <template
+                              v-for="link in item.links"
+                              :key="link.url"
+                            >
+                              <span class="text-gray-400"> (</span>
+                              <a
+                                :href="link.url"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-indigo-600 hover:underline"
+                                >{{ link.text }}</a
+                              >
+                              <span class="text-gray-400">)</span>
+                            </template>
+                          </span>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+              <div class="px-6 py-4 border-t border-gray-200 text-right">
+                <button
+                  type="button"
+                  class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                  @click="handleClose"
+                >
+                  Close
+                </button>
+              </div>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>

--- a/src/components/SettingsList/ChangelogDialog.vue
+++ b/src/components/SettingsList/ChangelogDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import {
   TransitionRoot,
   TransitionChild,
@@ -8,7 +9,7 @@ import {
 } from '@headlessui/vue'
 import { parseInline, type Changelog } from '../../data/model/Changelog'
 
-defineProps<{
+const props = defineProps<{
   show: boolean
   changelog: Changelog
 }>()
@@ -16,6 +17,19 @@ defineProps<{
 const emit = defineEmits<{
   (event: 'update:show', value: boolean): void
 }>()
+
+const tokenizedReleases = computed(() =>
+  props.changelog.releases.map((release) => ({
+    ...release,
+    sections: release.sections.map((section) => ({
+      ...section,
+      items: section.items.map((item) => ({
+        ...item,
+        descriptionTokens: parseInline(item.description),
+      })),
+    })),
+  }))
+)
 
 const handleClose = () => {
   emit('update:show', false)
@@ -72,7 +86,7 @@ const handleClose = () => {
                 </p>
                 <ul v-else class="space-y-6">
                   <li
-                    v-for="release in changelog.releases"
+                    v-for="release in tokenizedReleases"
                     :key="release.version"
                   >
                     <h4 class="text-base font-semibold text-gray-900">
@@ -116,10 +130,10 @@ const handleClose = () => {
                             >
                             <span :class="{ 'ml-1': item.scope }">
                               <template
-                                v-for="(token, tokenIndex) in parseInline(
-                                  item.description
-                                )"
-                                :key="`tok-${tokenIndex}`"
+                                v-for="(
+                                  token, tokenIndex
+                                ) in item.descriptionTokens"
+                                :key="`${tokenIndex}-${token.type}`"
                               >
                                 <code
                                   v-if="token.type === 'code'"

--- a/src/components/SettingsList/ChangelogItem.vue
+++ b/src/components/SettingsList/ChangelogItem.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import SettingsListItem from './SettingsListItem.vue'
+import ChangelogDialog from './ChangelogDialog.vue'
+import changelogSource from '../../../CHANGELOG.md?raw'
+import { parseChangelog } from '../../data/model/Changelog'
+
+const changelog = parseChangelog(changelogSource)
+const latestVersion = changelog.releases[0]?.version
+
+const showDialog = ref(false)
+
+const handleClick = () => {
+  showDialog.value = true
+}
+</script>
+
+<template>
+  <SettingsListItem
+    as="button"
+    inner-class="w-full text-left"
+    @click="handleClick"
+  >
+    <p>Changelog</p>
+    <template v-if="latestVersion" #subtext
+      >Latest: {{ latestVersion }}</template
+    >
+  </SettingsListItem>
+  <ChangelogDialog
+    v-if="showDialog"
+    v-model:show="showDialog"
+    :changelog="changelog"
+  />
+</template>

--- a/src/components/SettingsList/SettingsList.vue
+++ b/src/components/SettingsList/SettingsList.vue
@@ -6,6 +6,7 @@ import PostPrefixItem from './PostPrefixItem.vue'
 import CopyToClipboardItem from './CopyToClipboardItem.vue'
 import AmazonDomainItem from './AmazonDomainItem.vue'
 import AmazonAssociateIdItem from './AmazonAssociateIdItem.vue'
+import ChangelogItem from './ChangelogItem.vue'
 import SettingsListHeader from './SettingsListHeader.vue'
 import { AppBskyActorDefs } from '@atproto/api'
 import SettingsListItem from './SettingsListItem.vue'
@@ -103,6 +104,7 @@ const handleUpdateAmazonAssociateId = (id: string) => {
         <p>App Version</p>
         <template #subtext>{{ appVersion }}</template>
       </SettingsListItem>
+      <ChangelogItem />
       <SettingsListItem as="a" :href="developer.url" target="_blank">
         <p>Developer</p>
         <template #subtext>{{ developer.name }}</template>

--- a/src/data/model/Changelog.test.ts
+++ b/src/data/model/Changelog.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import { parseChangelog } from './Changelog'
+
+describe('parseChangelog', () => {
+  it('returns no releases for an empty changelog', () => {
+    const result = parseChangelog('# Changelog\n')
+    expect(result.releases).toEqual([])
+  })
+
+  it('parses a release heading with a compare link and date', () => {
+    const md = `# Changelog
+
+## [0.0.4](https://github.com/yshrsmz/omniatp/compare/v0.0.3...v0.0.4) (2026-05-08)
+`
+    const result = parseChangelog(md)
+    expect(result.releases).toHaveLength(1)
+    expect(result.releases[0]).toMatchObject({
+      version: '0.0.4',
+      versionUrl: 'https://github.com/yshrsmz/omniatp/compare/v0.0.3...v0.0.4',
+      date: '2026-05-08',
+      sections: [],
+    })
+  })
+
+  it('parses a release heading without a compare link', () => {
+    const md = `# Changelog
+
+## 0.0.1 (2025-01-01)
+`
+    const result = parseChangelog(md)
+    expect(result.releases[0]).toMatchObject({
+      version: '0.0.1',
+      versionUrl: undefined,
+      date: '2025-01-01',
+    })
+  })
+
+  it('parses sections and items, including scope and trailing links', () => {
+    const md = `# Changelog
+
+## [0.0.4](https://example.com/c) (2026-05-08)
+
+
+### Features
+
+* copy posted message to clipboard ([#70](https://example.com/i70)) ([b50c0a3](https://example.com/cb50))
+* **share:** rewrite Amazon URLs with associate tag ([#92](https://example.com/i92)) ([3ec4370](https://example.com/c3ec))
+
+
+### Bug Fixes
+
+* **clipboard:** recreate offscreen document on each clipboard write ([#93](https://example.com/i93)) ([294466a](https://example.com/c294))
+`
+
+    const result = parseChangelog(md)
+    expect(result.releases).toHaveLength(1)
+    const release = result.releases[0]
+    expect(release.sections).toHaveLength(2)
+
+    const features = release.sections[0]
+    expect(features.title).toBe('Features')
+    expect(features.items).toEqual([
+      {
+        scope: undefined,
+        description: 'copy posted message to clipboard',
+        links: [
+          { text: '#70', url: 'https://example.com/i70' },
+          { text: 'b50c0a3', url: 'https://example.com/cb50' },
+        ],
+      },
+      {
+        scope: 'share',
+        description: 'rewrite Amazon URLs with associate tag',
+        links: [
+          { text: '#92', url: 'https://example.com/i92' },
+          { text: '3ec4370', url: 'https://example.com/c3ec' },
+        ],
+      },
+    ])
+
+    const bugFixes = release.sections[1]
+    expect(bugFixes.title).toBe('Bug Fixes')
+    expect(bugFixes.items).toHaveLength(1)
+    expect(bugFixes.items[0]).toMatchObject({
+      scope: 'clipboard',
+      description: 'recreate offscreen document on each clipboard write',
+    })
+  })
+
+  it('parses an item with no trailing links', () => {
+    const md = `# Changelog
+
+## 0.0.1 (2025-01-01)
+
+### Features
+
+* initial release
+`
+    const result = parseChangelog(md)
+    expect(result.releases[0].sections[0].items[0]).toEqual({
+      scope: undefined,
+      description: 'initial release',
+      links: [],
+    })
+  })
+
+  it('parses multiple releases in order', () => {
+    const md = `# Changelog
+
+## [0.0.4](https://example.com/a) (2026-05-08)
+
+### Features
+
+* later
+
+## [0.0.3](https://example.com/b) (2026-04-01)
+
+### Features
+
+* earlier
+`
+    const result = parseChangelog(md)
+    expect(result.releases.map((r) => r.version)).toEqual(['0.0.4', '0.0.3'])
+    expect(result.releases[0].sections[0].items[0].description).toBe('later')
+    expect(result.releases[1].sections[0].items[0].description).toBe('earlier')
+  })
+
+  it('ignores items that appear before any section', () => {
+    const md = `# Changelog
+
+## 0.0.1 (2025-01-01)
+
+* stray item
+`
+    const result = parseChangelog(md)
+    expect(result.releases[0].sections).toEqual([])
+  })
+})

--- a/src/data/model/Changelog.test.ts
+++ b/src/data/model/Changelog.test.ts
@@ -135,4 +135,50 @@ describe('parseChangelog', () => {
     const result = parseChangelog(md)
     expect(result.releases[0].sections).toEqual([])
   })
+
+  it('handles preamble paragraphs, emoji section titles, and prose items', () => {
+    const md = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.20.0](https://github.com/x/y/compare/v0.19.0...v0.20.0) (2026-05-05)
+
+
+### ⚠ BREAKING CHANGES
+
+* \`Foo\` fields are now \`Property<String>\`. Common-case usage (\`packageName = "..."\`) is preserved on Gradle 8.2+. Code reading \`extension.packageName\` directly must switch to \`.set(...)\` and \`.orNull\` / \`.get()\` respectively.
+
+### Features
+
+* support standalone Kotlin/JVM and Kotlin/JS projects ([#296](https://example.com/i296)) ([0e46e94](https://example.com/c0e4))
+
+### Code Refactoring
+
+* migrate to Provider API ([5d479eb](https://example.com/c5d4))
+`
+    const result = parseChangelog(md)
+    expect(result.releases).toHaveLength(1)
+    const release = result.releases[0]
+    expect(release.version).toBe('0.20.0')
+    expect(release.sections.map((s) => s.title)).toEqual([
+      '⚠ BREAKING CHANGES',
+      'Features',
+      'Code Refactoring',
+    ])
+
+    const breaking = release.sections[0].items[0]
+    expect(breaking.scope).toBeUndefined()
+    expect(breaking.description).toContain('Property<String>')
+    expect(breaking.description).toContain('packageName = "..."')
+    expect(breaking.links).toEqual([])
+
+    const refactor = release.sections[2].items[0]
+    expect(refactor.description).toBe('migrate to Provider API')
+    expect(refactor.links).toEqual([
+      { text: '5d479eb', url: 'https://example.com/c5d4' },
+    ])
+  })
 })

--- a/src/data/model/Changelog.test.ts
+++ b/src/data/model/Changelog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseChangelog } from './Changelog'
+import { parseChangelog, parseInline } from './Changelog'
 
 describe('parseChangelog', () => {
   it('returns no releases for an empty changelog', () => {
@@ -180,5 +180,66 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     expect(refactor.links).toEqual([
       { text: '5d479eb', url: 'https://example.com/c5d4' },
     ])
+  })
+})
+
+describe('parseInline', () => {
+  it('returns a single text token for plain prose', () => {
+    expect(parseInline('initial release')).toEqual([
+      { type: 'text', text: 'initial release' },
+    ])
+  })
+
+  it('returns an empty array for an empty string', () => {
+    expect(parseInline('')).toEqual([])
+  })
+
+  it('extracts a single code span', () => {
+    expect(parseInline('use `Property<String>` here')).toEqual([
+      { type: 'text', text: 'use ' },
+      { type: 'code', text: 'Property<String>' },
+      { type: 'text', text: ' here' },
+    ])
+  })
+
+  it('extracts a single bold span', () => {
+    expect(parseInline('the **important** thing')).toEqual([
+      { type: 'text', text: 'the ' },
+      { type: 'bold', text: 'important' },
+      { type: 'text', text: ' thing' },
+    ])
+  })
+
+  it('extracts multiple code spans intermixed with text', () => {
+    expect(parseInline('`Foo` fields are now `Property<String>`')).toEqual([
+      { type: 'code', text: 'Foo' },
+      { type: 'text', text: ' fields are now ' },
+      { type: 'code', text: 'Property<String>' },
+    ])
+  })
+
+  it('treats an unmatched backtick as plain text', () => {
+    expect(parseInline('half open `code')).toEqual([
+      { type: 'text', text: 'half open `code' },
+    ])
+  })
+
+  it('treats an unmatched ** as plain text', () => {
+    expect(parseInline('half open **bold')).toEqual([
+      { type: 'text', text: 'half open **bold' },
+    ])
+  })
+
+  it('does not recurse into nested formatting', () => {
+    expect(parseInline('**bold with `code` inside**')).toEqual([
+      { type: 'bold', text: 'bold with `code` inside' },
+    ])
+    expect(parseInline('`code with **stars** inside`')).toEqual([
+      { type: 'code', text: 'code with **stars** inside' },
+    ])
+  })
+
+  it('handles a single * by leaving it as text', () => {
+    expect(parseInline('a*b*c')).toEqual([{ type: 'text', text: 'a*b*c' }])
   })
 })

--- a/src/data/model/Changelog.ts
+++ b/src/data/model/Changelog.ts
@@ -44,6 +44,16 @@ export interface Changelog {
   releases: ChangelogRelease[]
 }
 
+/**
+ * A typed segment within an item description after inline-markdown parsing.
+ * Used by the renderer to apply `<code>` / `<strong>` styling to the
+ * appropriate ranges instead of leaking raw `` ` `` / `**` characters.
+ */
+export type InlineToken =
+  | { type: 'text'; text: string }
+  | { type: 'code'; text: string }
+  | { type: 'bold'; text: string }
+
 const RELEASE_HEADING_RE =
   /^##\s+(?:\[(?<linkVersion>[^\]]+)\]\((?<url>[^)]+)\)|(?<bareVersion>[^\s(]+))(?:\s+\((?<date>[^)]+)\))?\s*$/
 const SECTION_HEADING_RE = /^###\s+(?<title>.+?)\s*$/
@@ -74,6 +84,56 @@ const parseItem = (raw: string): ChangelogItem => {
     description: rest.trim(),
     links,
   }
+}
+
+/**
+ * Parses inline markdown formatting within an item description. Recognises
+ * `` `code` `` spans and `**bold**` spans only — no nesting, no italic, no
+ * inline links. The first delimiter encountered wins; an unmatched opener is
+ * left as plain text. This deliberately stays narrow because release-please's
+ * descriptions only use these two inline forms in practice.
+ */
+export const parseInline = (raw: string): InlineToken[] => {
+  const tokens: InlineToken[] = []
+  let i = 0
+  let textStart = 0
+
+  const flushText = (end: number) => {
+    if (end > textStart) {
+      tokens.push({ type: 'text', text: raw.slice(textStart, end) })
+    }
+  }
+
+  while (i < raw.length) {
+    if (raw[i] === '`') {
+      const close = raw.indexOf('`', i + 1)
+      if (close === -1) {
+        i++
+        continue
+      }
+      flushText(i)
+      tokens.push({ type: 'code', text: raw.slice(i + 1, close) })
+      i = close + 1
+      textStart = i
+      continue
+    }
+    if (raw[i] === '*' && raw[i + 1] === '*') {
+      const close = raw.indexOf('**', i + 2)
+      if (close === -1) {
+        i++
+        continue
+      }
+      flushText(i)
+      tokens.push({ type: 'bold', text: raw.slice(i + 2, close) })
+      i = close + 2
+      textStart = i
+      continue
+    }
+    i++
+  }
+
+  flushText(raw.length)
+  return tokens
 }
 
 /**

--- a/src/data/model/Changelog.ts
+++ b/src/data/model/Changelog.ts
@@ -1,0 +1,125 @@
+/**
+ * A markdown link extracted from the trailing parens of a changelog item
+ * (typically a PR number or a commit SHA).
+ */
+export interface ChangelogLink {
+  text: string
+  url: string
+}
+
+/**
+ * One bullet under a release section. `scope` corresponds to the leading
+ * `**scope:**` emitted by Conventional Commits.
+ */
+export interface ChangelogItem {
+  scope?: string
+  description: string
+  links: ChangelogLink[]
+}
+
+/**
+ * A grouping of items under a release (e.g. "Features", "Bug Fixes").
+ */
+export interface ChangelogSection {
+  title: string
+  items: ChangelogItem[]
+}
+
+/**
+ * One release entry parsed from CHANGELOG.md (`## …` heading and its body).
+ * `versionUrl` points at the GitHub compare URL when present.
+ */
+export interface ChangelogRelease {
+  version: string
+  versionUrl?: string
+  date?: string
+  sections: ChangelogSection[]
+}
+
+/**
+ * The full parsed CHANGELOG.md, with releases in source order
+ * (newest first, as release-please writes them).
+ */
+export interface Changelog {
+  releases: ChangelogRelease[]
+}
+
+const RELEASE_HEADING_RE =
+  /^##\s+(?:\[(?<linkVersion>[^\]]+)\]\((?<url>[^)]+)\)|(?<bareVersion>[^\s(]+))(?:\s+\((?<date>[^)]+)\))?\s*$/
+const SECTION_HEADING_RE = /^###\s+(?<title>.+?)\s*$/
+const ITEM_PREFIX_RE = /^[*-]\s+(?<rest>.*)$/
+const SCOPE_PREFIX_RE = /^\*\*(?<scope>[^*]+?):\*\*\s+(?<rest>.*)$/
+const TRAILING_LINK_RE = /\s*\(\[(?<text>[^\]]+)\]\((?<url>[^)]+)\)\)\s*$/
+
+const parseItem = (raw: string): ChangelogItem => {
+  let rest = raw.trim()
+  const links: ChangelogLink[] = []
+
+  while (true) {
+    const match = rest.match(TRAILING_LINK_RE)
+    if (!match?.groups) break
+    links.unshift({ text: match.groups.text, url: match.groups.url })
+    rest = rest.slice(0, match.index).trimEnd()
+  }
+
+  let scope: string | undefined
+  const scopeMatch = rest.match(SCOPE_PREFIX_RE)
+  if (scopeMatch?.groups) {
+    scope = scopeMatch.groups.scope
+    rest = scopeMatch.groups.rest
+  }
+
+  return {
+    scope,
+    description: rest.trim(),
+    links,
+  }
+}
+
+/**
+ * Parses a release-please-style CHANGELOG.md into structured data.
+ *
+ * Recognised lines:
+ * - `## [version](url) (date)` or `## version (date)` → release
+ * - `### Title` → section under the current release
+ * - `* …` or `- …` → item under the current section
+ *
+ * Anything else is ignored; items before any section are dropped.
+ */
+export const parseChangelog = (markdown: string): Changelog => {
+  const lines = markdown.split(/\r?\n/)
+  const releases: ChangelogRelease[] = []
+  let currentRelease: ChangelogRelease | undefined
+  let currentSection: ChangelogSection | undefined
+
+  for (const line of lines) {
+    const releaseMatch = line.match(RELEASE_HEADING_RE)
+    if (releaseMatch?.groups) {
+      const { linkVersion, bareVersion, url, date } = releaseMatch.groups
+      currentRelease = {
+        version: linkVersion ?? bareVersion,
+        versionUrl: url,
+        date,
+        sections: [],
+      }
+      currentSection = undefined
+      releases.push(currentRelease)
+      continue
+    }
+
+    const sectionMatch = line.match(SECTION_HEADING_RE)
+    if (sectionMatch?.groups && currentRelease) {
+      currentSection = { title: sectionMatch.groups.title, items: [] }
+      currentRelease.sections.push(currentSection)
+      continue
+    }
+
+    const itemMatch = line.match(ITEM_PREFIX_RE)
+    if (itemMatch?.groups && currentSection) {
+      currentSection.items.push(parseItem(itemMatch.groups.rest))
+      continue
+    }
+  }
+
+  return { releases }
+}


### PR DESCRIPTION
## Summary

- Add a "Changelog" item under the **Others** section of the options page; clicking it opens a dialog that renders the parsed `CHANGELOG.md`.
- New `parseChangelog` model parses release-please's output format into structured data (no runtime markdown library — links and scope are extracted via regex and rendered with Vue components).
- Add two project rules: `comments.md` (require JSDoc on exports) and `asking.md` (default to AskUserQuestion when asking the user a question).

Closes #16.

## Design notes

- Display: modal dialog (consistent with existing `SignInDialog` / `SignOutDialog` / `TextInputDialog`).
- Range: full changelog with internal scroll (small file, grows slowly).
- Parsing: structured AST built at component mount; no `v-html`.

The four dialogs in this repo now share ~25 lines of identical Headless UI scaffolding. Refactor tracked separately in #96 to keep this PR scoped.

## Test plan

- [x] `pnpm test` — 24 files / 160 tests pass (12 new: 7 parser + 5 dialog)
- [x] `pnpm compile` — clean
- [x] `pnpm build` — production build succeeds; `?raw` import resolves
- [ ] Manual smoke: open options page, click "Changelog", verify dialog renders releases / sections / links and closes via the Close button or backdrop click

🤖 Generated with [Claude Code](https://claude.com/claude-code)