### PR TITLE
refactor(components): extract BaseDialog to deduplicate dialog chrome

### DIFF
--- a/src/components/BaseDialog.test.ts
+++ b/src/components/BaseDialog.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import BaseDialog from './BaseDialog.vue'
+import { headlessuiStubs } from '../test/headlessui-stubs'
+
+const PANEL_TEXT = 'panel content'
+
+const mountDialog = (
+  props: { show: boolean; static?: boolean } = { show: true }
+) =>
+  mount(BaseDialog, {
+    props,
+    slots: {
+      default: () => h('div', { class: 'panel' }, PANEL_TEXT),
+    },
+    global: { stubs: headlessuiStubs },
+  })
+
+describe('BaseDialog', () => {
+  it('does not render the slot when show is false', () => {
+    const wrapper = mountDialog({ show: false })
+    expect(wrapper.text()).not.toContain(PANEL_TEXT)
+  })
+
+  it('renders the slot when show is true', () => {
+    const wrapper = mountDialog({ show: true })
+    expect(wrapper.text()).toContain(PANEL_TEXT)
+  })
+
+  it('emits update:show=false on close when not static', async () => {
+    const wrapper = mountDialog({ show: true, static: false })
+    await wrapper.findComponent({ name: 'Dialog' }).trigger('click')
+    expect(wrapper.emitted('update:show')?.[0]).toEqual([false])
+  })
+
+  it('does not emit update:show on close when static is true', async () => {
+    const wrapper = mountDialog({ show: true, static: true })
+    await wrapper.findComponent({ name: 'Dialog' }).trigger('click')
+    expect(wrapper.emitted('update:show')).toBeUndefined()
+  })
+})

--- a/src/components/BaseDialog.vue
+++ b/src/components/BaseDialog.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { TransitionRoot, TransitionChild, Dialog } from '@headlessui/vue'
+
+const props = withDefaults(
+  defineProps<{
+    show: boolean
+    static?: boolean
+  }>(),
+  {
+    static: false,
+  }
+)
+
+const emit = defineEmits<{
+  (event: 'update:show', value: boolean): void
+}>()
+
+const handleClose = () => {
+  if (!props.static) {
+    emit('update:show', false)
+  }
+}
+</script>
+
+<template>
+  <TransitionRoot appear :show="show" as="template">
+    <Dialog
+      as="div"
+      :static="static"
+      class="relative z-10"
+      @close="handleClose"
+    >
+      <TransitionChild
+        as="template"
+        enter="duration-300 ease-out"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="duration-200 ease-in"
+        leave-from="opacity-100"
+        leave-to="opacity-0"
+      >
+        <div class="fixed inset-0 bg-black/25" />
+      </TransitionChild>
+
+      <div class="fixed inset-0 overflow-y-auto">
+        <div
+          class="flex min-h-full items-center justify-center p-4 text-center"
+        >
+          <TransitionChild
+            as="template"
+            enter="duration-300 ease-out"
+            enter-from="opacity-0 scale-95"
+            enter-to="opacity-100 scale-100"
+            leave="duration-200 ease-in"
+            leave-from="opacity-100 scale-100"
+            leave-to="opacity-0 scale-95"
+          >
+            <slot />
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>

--- a/src/components/SettingsList/ChangelogDialog.vue
+++ b/src/components/SettingsList/ChangelogDialog.vue
@@ -1,13 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import {
-  TransitionRoot,
-  TransitionChild,
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-} from '@headlessui/vue'
+import { DialogPanel, DialogTitle } from '@headlessui/vue'
 import { parseInline, type Changelog } from '../../data/model/Changelog'
+import BaseDialog from '../BaseDialog.vue'
 
 const props = defineProps<{
   show: boolean
@@ -37,151 +32,106 @@ const handleClose = () => {
 </script>
 
 <template>
-  <TransitionRoot appear :show="show" as="template">
-    <Dialog
-      as="div"
-      class="ChangelogDialog relative z-10"
-      @close="emit('update:show', false)"
+  <BaseDialog :show="show" @update:show="emit('update:show', $event)">
+    <DialogPanel
+      class="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white text-left align-middle shadow-xl transition-all flex flex-col max-h-[80vh]"
     >
-      <TransitionChild
-        as="template"
-        enter="duration-300 ease-out"
-        enter-from="opacity-0"
-        enter-to="opacity-100"
-        leave="duration-200 ease-in"
-        leave-from="opacity-100"
-        leave-to="opacity-0"
+      <DialogTitle
+        as="h3"
+        class="text-lg font-medium leading-6 text-gray-900 px-6 pt-6"
       >
-        <div class="fixed inset-0 bg-black bg-opacity-25" />
-      </TransitionChild>
-
-      <div class="fixed inset-0 overflow-y-auto">
-        <div
-          class="flex min-h-full items-center justify-center p-4 text-center"
-        >
-          <TransitionChild
-            as="template"
-            enter="duration-300 ease-out"
-            enter-from="opacity-0 scale-95"
-            enter-to="opacity-100 scale-100"
-            leave="duration-200 ease-in"
-            leave-from="opacity-100 scale-100"
-            leave-to="opacity-0 scale-95"
-          >
-            <DialogPanel
-              class="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white text-left align-middle shadow-xl transition-all flex flex-col max-h-[80vh]"
-            >
-              <DialogTitle
-                as="h3"
-                class="text-lg font-medium leading-6 text-gray-900 px-6 pt-6"
+        Changelog
+      </DialogTitle>
+      <div class="mt-4 px-6 overflow-y-auto flex-1">
+        <p v-if="changelog.releases.length === 0" class="text-sm text-gray-500">
+          No releases yet.
+        </p>
+        <ul v-else class="space-y-6">
+          <li v-for="release in tokenizedReleases" :key="release.version">
+            <h4 class="text-base font-semibold text-gray-900">
+              <a
+                v-if="release.versionUrl"
+                :href="release.versionUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-indigo-600 hover:underline"
               >
-                Changelog
-              </DialogTitle>
-              <div class="mt-4 px-6 overflow-y-auto flex-1">
-                <p
-                  v-if="changelog.releases.length === 0"
-                  class="text-sm text-gray-500"
+                {{ release.version }}
+              </a>
+              <span v-else>{{ release.version }}</span>
+              <span
+                v-if="release.date"
+                class="ml-2 text-sm font-normal text-gray-500"
+              >
+                {{ release.date }}
+              </span>
+            </h4>
+            <div
+              v-for="section in release.sections"
+              :key="section.title"
+              class="mt-3"
+            >
+              <h5
+                class="text-sm font-medium text-gray-700 uppercase tracking-wide"
+              >
+                {{ section.title }}
+              </h5>
+              <ul class="mt-1 space-y-1 text-sm text-gray-700">
+                <li
+                  v-for="(item, index) in section.items"
+                  :key="`${section.title}-${index}`"
+                  class="flex"
                 >
-                  No releases yet.
-                </p>
-                <ul v-else class="space-y-6">
-                  <li
-                    v-for="release in tokenizedReleases"
-                    :key="release.version"
-                  >
-                    <h4 class="text-base font-semibold text-gray-900">
+                  <span class="mr-2 text-gray-400">•</span>
+                  <span class="flex-1">
+                    <strong v-if="item.scope" class="font-semibold"
+                      >{{ item.scope }}:</strong
+                    >
+                    <span :class="{ 'ml-1': item.scope }">
+                      <template
+                        v-for="(token, tokenIndex) in item.descriptionTokens"
+                        :key="`${tokenIndex}-${token.type}`"
+                      >
+                        <code
+                          v-if="token.type === 'code'"
+                          class="rounded bg-gray-100 px-1 font-mono text-xs"
+                          >{{ token.text }}</code
+                        >
+                        <strong
+                          v-else-if="token.type === 'bold'"
+                          class="font-semibold"
+                          >{{ token.text }}</strong
+                        >
+                        <template v-else>{{ token.text }}</template>
+                      </template>
+                    </span>
+                    <template v-for="link in item.links" :key="link.url">
+                      <span class="text-gray-400"> (</span>
                       <a
-                        v-if="release.versionUrl"
-                        :href="release.versionUrl"
+                        :href="link.url"
                         target="_blank"
                         rel="noopener noreferrer"
                         class="text-indigo-600 hover:underline"
+                        >{{ link.text }}</a
                       >
-                        {{ release.version }}
-                      </a>
-                      <span v-else>{{ release.version }}</span>
-                      <span
-                        v-if="release.date"
-                        class="ml-2 text-sm font-normal text-gray-500"
-                      >
-                        {{ release.date }}
-                      </span>
-                    </h4>
-                    <div
-                      v-for="section in release.sections"
-                      :key="section.title"
-                      class="mt-3"
-                    >
-                      <h5
-                        class="text-sm font-medium text-gray-700 uppercase tracking-wide"
-                      >
-                        {{ section.title }}
-                      </h5>
-                      <ul class="mt-1 space-y-1 text-sm text-gray-700">
-                        <li
-                          v-for="(item, index) in section.items"
-                          :key="`${section.title}-${index}`"
-                          class="flex"
-                        >
-                          <span class="mr-2 text-gray-400">•</span>
-                          <span class="flex-1">
-                            <strong v-if="item.scope" class="font-semibold"
-                              >{{ item.scope }}:</strong
-                            >
-                            <span :class="{ 'ml-1': item.scope }">
-                              <template
-                                v-for="(
-                                  token, tokenIndex
-                                ) in item.descriptionTokens"
-                                :key="`${tokenIndex}-${token.type}`"
-                              >
-                                <code
-                                  v-if="token.type === 'code'"
-                                  class="rounded bg-gray-100 px-1 font-mono text-xs"
-                                  >{{ token.text }}</code
-                                >
-                                <strong
-                                  v-else-if="token.type === 'bold'"
-                                  class="font-semibold"
-                                  >{{ token.text }}</strong
-                                >
-                                <template v-else>{{ token.text }}</template>
-                              </template>
-                            </span>
-                            <template
-                              v-for="link in item.links"
-                              :key="link.url"
-                            >
-                              <span class="text-gray-400"> (</span>
-                              <a
-                                :href="link.url"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="text-indigo-600 hover:underline"
-                                >{{ link.text }}</a
-                              >
-                              <span class="text-gray-400">)</span>
-                            </template>
-                          </span>
-                        </li>
-                      </ul>
-                    </div>
-                  </li>
-                </ul>
-              </div>
-              <div class="px-6 py-4 border-t border-gray-200 text-right">
-                <button
-                  type="button"
-                  class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                  @click="handleClose"
-                >
-                  Close
-                </button>
-              </div>
-            </DialogPanel>
-          </TransitionChild>
-        </div>
+                      <span class="text-gray-400">)</span>
+                    </template>
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
       </div>
-    </Dialog>
-  </TransitionRoot>
+      <div class="px-6 py-4 border-t border-gray-200 text-right">
+        <button
+          type="button"
+          class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          @click="handleClose"
+        >
+          Close
+        </button>
+      </div>
+    </DialogPanel>
+  </BaseDialog>
 </template>

--- a/src/components/SettingsList/SignInDialog.vue
+++ b/src/components/SettingsList/SignInDialog.vue
@@ -1,17 +1,12 @@
 <script setup lang="ts">
-import {
-  TransitionRoot,
-  TransitionChild,
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-} from '@headlessui/vue'
+import { DialogPanel, DialogTitle } from '@headlessui/vue'
 import { ExclamationCircleIcon } from '@heroicons/vue/20/solid'
 import TextField from '../forms/TextField.vue'
 import { computed, ref } from 'vue'
 import { suite, LoginCredential } from '../../data/model/LoginCredential'
 import { AuthProgress } from '../../data/model/AuthProgress'
 import LoadingSpinner from '../LoadingSpinner.vue'
+import BaseDialog from '../BaseDialog.vue'
 
 const props = defineProps<{
   show: boolean
@@ -76,112 +71,77 @@ const handleFormSubmit = () => {
 </script>
 
 <template>
-  <TransitionRoot appear :show="show" as="template">
-    <Dialog as="div" :static="true" class="SignInDialog relative z-10">
-      <TransitionChild
-        as="template"
-        enter="duration-300 ease-out"
-        enter-from="opacity-0"
-        enter-to="opacity-100"
-        leave="duration-200 ease-in"
-        leave-from="opacity-100"
-        leave-to="opacity-0"
+  <BaseDialog :show="show" :static="true">
+    <DialogPanel
+      class="relative w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
+    >
+      <DialogTitle as="h3" class="text-lg font-medium leading-6 text-gray-900">
+        Login to Bluesky
+      </DialogTitle>
+      <form
+        method="post"
+        class="space-y-1 mt-6"
+        @submit.prevent="handleFormSubmit"
+        @input="handleFormInput"
       >
-        <div class="fixed inset-0 bg-black bg-opacity-25" />
-      </TransitionChild>
-
-      <div class="fixed inset-0 overflow-y-auto">
-        <div
-          class="flex min-h-full items-center justify-center p-4 text-center"
-        >
-          <TransitionChild
-            as="template"
-            enter="duration-300 ease-out"
-            enter-from="opacity-0 scale-95"
-            enter-to="opacity-100 scale-100"
-            leave="duration-200 ease-in"
-            leave-from="opacity-100 scale-100"
-            leave-to="opacity-0 scale-95"
+        <TextField
+          type="text"
+          name="service"
+          title="Service"
+          readonly
+          disabled
+          :value="service"
+        />
+        <TextField
+          v-model:value="identifierRef"
+          type="text"
+          name="identifier"
+          title="Identifier"
+          placeholder="your@email.address, @your_handle, or did:plc:yourdid"
+          :disabled="shouldDisableInput"
+          :error="identifierErrorRef"
+        />
+        <TextField
+          v-model:value="passwordRef"
+          type="password"
+          name="password"
+          title="Password"
+          :disabled="shouldDisableInput"
+          :error="passwordErrorRef"
+        />
+        <p v-if="progress.type === 'ERROR'" class="flex flex-row">
+          <ExclamationCircleIcon
+            class="h-5 w-5 text-red-500"
+            aria-hidden="true"
+          />
+          <span class="text-sm text-red-600 ml-2">{{ progress.message }}</span>
+        </p>
+        <div class="!mt-6 grid grid-cols-2 gap-4">
+          <button
+            type="button"
+            :disabled="shouldDisableInput"
+            class="flex w-full justify-center rounded-md bg-red-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
+            @click="handleCancel"
           >
-            <DialogPanel
-              class="relative w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
-            >
-              <DialogTitle
-                as="h3"
-                class="text-lg font-medium leading-6 text-gray-900"
-              >
-                Login to Bluesky
-              </DialogTitle>
-              <form
-                method="post"
-                class="space-y-1 mt-6"
-                @submit.prevent="handleFormSubmit"
-                @input="handleFormInput"
-              >
-                <TextField
-                  type="text"
-                  name="service"
-                  title="Service"
-                  readonly
-                  disabled
-                  :value="service"
-                />
-                <TextField
-                  v-model:value="identifierRef"
-                  type="text"
-                  name="identifier"
-                  title="Identifier"
-                  placeholder="your@email.address, @your_handle, or did:plc:yourdid"
-                  :disabled="shouldDisableInput"
-                  :error="identifierErrorRef"
-                />
-                <TextField
-                  v-model:value="passwordRef"
-                  type="password"
-                  name="password"
-                  title="Password"
-                  :disabled="shouldDisableInput"
-                  :error="passwordErrorRef"
-                />
-                <p v-if="progress.type === 'ERROR'" class="flex flex-row">
-                  <ExclamationCircleIcon
-                    class="h-5 w-5 text-red-500"
-                    aria-hidden="true"
-                  />
-                  <span class="text-sm text-red-600 ml-2">{{
-                    progress.message
-                  }}</span>
-                </p>
-                <div class="!mt-6 grid grid-cols-2 gap-4">
-                  <button
-                    type="button"
-                    :disabled="shouldDisableInput"
-                    class="flex w-full justify-center rounded-md bg-red-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
-                    @click="handleCancel"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="submit"
-                    :disabled="!canSubmit || shouldDisableInput"
-                    class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50"
-                  >
-                    Sign in
-                  </button>
-                </div>
-              </form>
-              <div
-                v-if="progress.type === 'IN_PROGRESS'"
-                class="fixed inset-0 block h-full w-full bg-gray-500 opacity-60"
-              >
-                <div class="flex min-h-full justify-center items-center">
-                  <LoadingSpinner class="m-auto" />
-                </div>
-              </div>
-            </DialogPanel>
-          </TransitionChild>
+            Cancel
+          </button>
+          <button
+            type="submit"
+            :disabled="!canSubmit || shouldDisableInput"
+            class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50"
+          >
+            Sign in
+          </button>
+        </div>
+      </form>
+      <div
+        v-if="progress.type === 'IN_PROGRESS'"
+        class="fixed inset-0 block h-full w-full bg-gray-500 opacity-60"
+      >
+        <div class="flex min-h-full justify-center items-center">
+          <LoadingSpinner class="m-auto" />
         </div>
       </div>
-    </Dialog>
-  </TransitionRoot>
+    </DialogPanel>
+  </BaseDialog>
 </template>

--- a/src/components/SettingsList/SignOutDialog.vue
+++ b/src/components/SettingsList/SignOutDialog.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
-import {
-  TransitionRoot,
-  TransitionChild,
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-} from '@headlessui/vue'
+import { DialogPanel, DialogTitle } from '@headlessui/vue'
+import BaseDialog from '../BaseDialog.vue'
 
 defineProps<{
   show: boolean
@@ -27,70 +22,33 @@ const handleCloseClick = () => {
 </script>
 
 <template>
-  <TransitionRoot appear :show="show" as="template">
-    <Dialog
-      as="div"
-      class="SignOutDialog relative z-10"
-      @close="emit('update:show', false)"
+  <BaseDialog :show="show" @update:show="emit('update:show', $event)">
+    <DialogPanel
+      class="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
     >
-      <TransitionChild
-        as="template"
-        enter="duration-300 ease-out"
-        enter-from="opacity-0"
-        enter-to="opacity-100"
-        leave="duration-200 ease-in"
-        leave-from="opacity-100"
-        leave-to="opacity-0"
-      >
-        <div class="fixed inset-0 bg-black bg-opacity-25" />
-      </TransitionChild>
-
-      <div class="fixed inset-0 overflow-y-auto">
-        <div
-          class="flex min-h-full items-center justify-center p-4 text-center"
-        >
-          <TransitionChild
-            as="template"
-            enter="duration-300 ease-out"
-            enter-from="opacity-0 scale-95"
-            enter-to="opacity-100 scale-100"
-            leave="duration-200 ease-in"
-            leave-from="opacity-100 scale-100"
-            leave-to="opacity-0 scale-95"
-          >
-            <DialogPanel
-              class="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
-            >
-              <DialogTitle
-                as="h3"
-                class="text-lg font-medium leading-6 text-gray-900"
-              >
-                Confirm
-              </DialogTitle>
-              <div class="mt-2">
-                <p class="text-sm text-gray-500">Are you sure to sign out?</p>
-              </div>
-
-              <div class="mt-4">
-                <button
-                  type="button"
-                  class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 mr-2"
-                  @click="handleCloseClick"
-                >
-                  CLOSE
-                </button>
-                <button
-                  type="button"
-                  class="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-                  @click="handleSignOutClick"
-                >
-                  Sign out
-                </button>
-              </div>
-            </DialogPanel>
-          </TransitionChild>
-        </div>
+      <DialogTitle as="h3" class="text-lg font-medium leading-6 text-gray-900">
+        Confirm
+      </DialogTitle>
+      <div class="mt-2">
+        <p class="text-sm text-gray-500">Are you sure to sign out?</p>
       </div>
-    </Dialog>
-  </TransitionRoot>
+
+      <div class="mt-4">
+        <button
+          type="button"
+          class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 mr-2"
+          @click="handleCloseClick"
+        >
+          CLOSE
+        </button>
+        <button
+          type="button"
+          class="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          @click="handleSignOutClick"
+        >
+          Sign out
+        </button>
+      </div>
+    </DialogPanel>
+  </BaseDialog>
 </template>

--- a/src/components/TextInputDialog.vue
+++ b/src/components/TextInputDialog.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import {
-  TransitionRoot,
-  TransitionChild,
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-} from '@headlessui/vue'
+import { DialogPanel, DialogTitle } from '@headlessui/vue'
+import BaseDialog from './BaseDialog.vue'
 import TextField from './forms/TextField.vue'
 
 const props = withDefaults(
@@ -33,12 +28,6 @@ const emit = defineEmits<{
 
 const textRef = ref(props.text)
 
-const handleClose = () => {
-  if (props.cancelable) {
-    emit('update:show', false)
-  }
-}
-
 const onSave = () => {
   emit('update:show', false)
   emit('update:text', textRef.value)
@@ -47,79 +36,45 @@ const onSave = () => {
 </script>
 
 <template>
-  <TransitionRoot appear :show="show" as="template">
-    <Dialog
-      as="div"
-      :static="!cancelable"
-      class="TwitterPinCodeDialog relative z-10"
-      @close="handleClose"
+  <BaseDialog
+    :show="show"
+    :static="!cancelable"
+    @update:show="emit('update:show', $event)"
+  >
+    <DialogPanel
+      class="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
     >
-      <TransitionChild
-        as="template"
-        enter="duration-300 ease-out"
-        enter-from="opacity-0"
-        enter-to="opacity-100"
-        leave="duration-200 ease-in"
-        leave-from="opacity-100"
-        leave-to="opacity-0"
-      >
-        <div class="fixed inset-0 bg-black bg-opacity-25" />
-      </TransitionChild>
-      s
-      <div class="fixed inset-0 overflow-y-auto">
-        <div
-          class="flex min-h-full items-center justify-center p-4 text-center"
-        >
-          <TransitionChild
-            as="template"
-            enter="duration-300 ease-out"
-            enter-from="opacity-0 scale-95"
-            enter-to="opacity-100 scale-100"
-            leave="duration-200 ease-in"
-            leave-from="opacity-100 scale-100"
-            leave-to="opacity-0 scale-95"
-          >
-            <DialogPanel
-              class="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
-            >
-              <DialogTitle
-                as="h3"
-                class="text-lg font-medium leading-6 text-gray-900"
-              >
-                {{ title }}
-              </DialogTitle>
-              <div class="mt-2">
-                <TextField
-                  v-model:value="textRef"
-                  :title="title"
-                  :name="name"
-                  :type="type"
-                  :label="label"
-                  :placeholder="placeholder"
-                />
-              </div>
-
-              <div class="mt-4">
-                <button
-                  v-if="cancelable"
-                  type="button"
-                  class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 mr-2"
-                  @click="emit('update:show', false)"
-                >
-                  CLOSE
-                </button>
-                <button
-                  type="button"
-                  class="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-                  @click="onSave"
-                >
-                  SAVE
-                </button>
-              </div>
-            </DialogPanel>
-          </TransitionChild>
-        </div>
+      <DialogTitle as="h3" class="text-lg font-medium leading-6 text-gray-900">
+        {{ title }}
+      </DialogTitle>
+      <div class="mt-2">
+        <TextField
+          v-model:value="textRef"
+          :title="title"
+          :name="name"
+          :type="type"
+          :label="label"
+          :placeholder="placeholder"
+        />
       </div>
-    </Dialog>
-  </TransitionRoot>
+
+      <div class="mt-4">
+        <button
+          v-if="cancelable"
+          type="button"
+          class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 mr-2"
+          @click="emit('update:show', false)"
+        >
+          CLOSE
+        </button>
+        <button
+          type="button"
+          class="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          @click="onSave"
+        >
+          SAVE
+        </button>
+      </div>
+    </DialogPanel>
+  </BaseDialog>
 </template>


### PR DESCRIPTION
## Summary

- Extracts a `BaseDialog` component owning the shared chrome (`TransitionRoot` / `Dialog` / backdrop / centering wrapper) and migrates `SignInDialog`, `SignOutDialog`, `TextInputDialog`, and `ChangelogDialog` to it.
- Restores the intended semi-transparent backdrop. The current `bg-black bg-opacity-25` evaluates to fully opaque black under Tailwind v4, which dropped the `bg-opacity-*` utilities; `BaseDialog` uses the v4 syntax `bg-black/25` instead.
- Per-dialog panel layout, footer button sets, and `DialogTitle` styling stay in each dialog (explicit non-goals from the issue).

## Test plan

- [x] `pnpm test` (175/175)
- [x] `pnpm compile`
- [x] `pnpm build`
- [ ] Open each dialog in the dev build and verify open/cancel/submit transitions and the new semi-transparent backdrop.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)