### PR TITLE
chore(styles): finish Tailwind v4 utility migration

### DIFF
--- a/src/components/SettingsList/AmazonDomainItem.vue
+++ b/src/components/SettingsList/AmazonDomainItem.vue
@@ -35,7 +35,7 @@ const options = computed(() => [PLACEHOLDER, ...props.amazonDomains])
       <Listbox v-model="selected" class="mt-1 w-72">
         <div class="relative">
           <ListboxButton
-            class="relative w-full cursor-default rounded-md bg-white py-2 pl-3 pr-10 text-left text-gray-900 shadow ring-1 ring-inset ring-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            class="relative w-full cursor-default rounded-md bg-white py-2 pl-3 pr-10 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-500"
           >
             <span class="block truncate">{{ selected }}</span>
             <span
@@ -53,7 +53,7 @@ const options = computed(() => [PLACEHOLDER, ...props.amazonDomains])
             leave-to-class="opacity-0"
           >
             <ListboxOptions
-              class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none"
+              class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-hidden"
             >
               <ListboxOption
                 v-for="option in options"

--- a/src/components/SettingsList/AuthItem.vue
+++ b/src/components/SettingsList/AuthItem.vue
@@ -75,7 +75,7 @@ const handleSignOut = () => {
       <div v-if="progress.type !== 'INITIALIZING'">
         <button
           v-if="progress.type === 'AUTHORIZED'"
-          class="inline-flex items-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-red-600 hover:bg-red-700 focus:ring-red-500"
+          class="inline-flex items-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white shadow-xs focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-red-600 hover:bg-red-700 focus:ring-red-500"
           type="button"
           @click="handleSignOutClick"
         >
@@ -83,7 +83,7 @@ const handleSignOut = () => {
         </button>
         <button
           v-else
-          class="inline-flex items-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"
+          class="inline-flex items-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white shadow-xs focus:outline-hidden focus:ring-2 focus:ring-offset-2 bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500"
           type="button"
           @click="handleSignInClick"
         >

--- a/src/components/SettingsList/ChangelogDialog.vue
+++ b/src/components/SettingsList/ChangelogDialog.vue
@@ -94,7 +94,7 @@ const handleClose = () => {
                       >
                         <code
                           v-if="token.type === 'code'"
-                          class="rounded bg-gray-100 px-1 font-mono text-xs"
+                          class="rounded-sm bg-gray-100 px-1 font-mono text-xs"
                           >{{ token.text }}</code
                         >
                         <strong
@@ -126,7 +126,7 @@ const handleClose = () => {
       <div class="px-6 py-4 border-t border-gray-200 text-right">
         <button
           type="button"
-          class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-xs hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
           @click="handleClose"
         >
           Close

--- a/src/components/SettingsList/CopyToClipboardItem.vue
+++ b/src/components/SettingsList/CopyToClipboardItem.vue
@@ -27,7 +27,7 @@ const enabledRef = computed({
       v-model="enabledRef"
       :class="[
         enabledRef ? 'bg-blue-600' : 'bg-gray-200',
-        'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
+        'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2',
       ]"
     >
       <span class="sr-only">Toggle copy to clipboard on post</span>
@@ -35,7 +35,7 @@ const enabledRef = computed({
         aria-hidden="true"
         :class="[
           enabledRef ? 'translate-x-5' : 'translate-x-0',
-          'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+          'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow-sm ring-0 transition duration-200 ease-in-out',
         ]"
       />
     </Switch>

--- a/src/components/SettingsList/SettingsList.vue
+++ b/src/components/SettingsList/SettingsList.vue
@@ -69,7 +69,7 @@ const handleUpdateAmazonAssociateId = (id: string) => {
 </script>
 
 <template>
-  <div class="SettingsList overflow-hidden rounded-md bg-white shadow">
+  <div class="SettingsList overflow-hidden rounded-md bg-white shadow-sm">
     <ul role="list">
       <SettingsListHeader title="Auth" />
       <AuthItem

--- a/src/components/SettingsList/SignInDialog.vue
+++ b/src/components/SettingsList/SignInDialog.vue
@@ -120,7 +120,7 @@ const handleFormSubmit = () => {
           <button
             type="button"
             :disabled="shouldDisableInput"
-            class="flex w-full justify-center rounded-md bg-red-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
+            class="flex w-full justify-center rounded-md bg-red-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
             @click="handleCancel"
           >
             Cancel
@@ -128,7 +128,7 @@ const handleFormSubmit = () => {
           <button
             type="submit"
             :disabled="!canSubmit || shouldDisableInput"
-            class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50"
+            class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50"
           >
             Sign in
           </button>

--- a/src/components/SettingsList/SignOutDialog.vue
+++ b/src/components/SettingsList/SignOutDialog.vue
@@ -36,14 +36,14 @@ const handleCloseClick = () => {
       <div class="mt-4">
         <button
           type="button"
-          class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 mr-2"
+          class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-xs hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 mr-2"
           @click="handleCloseClick"
         >
           CLOSE
         </button>
         <button
           type="button"
-          class="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          class="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
           @click="handleSignOutClick"
         >
           Sign out

--- a/src/components/TextInputDialog.vue
+++ b/src/components/TextInputDialog.vue
@@ -62,14 +62,14 @@ const onSave = () => {
         <button
           v-if="cancelable"
           type="button"
-          class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 mr-2"
+          class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-xs hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 mr-2"
           @click="emit('update:show', false)"
         >
           CLOSE
         </button>
         <button
           type="button"
-          class="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          class="inline-flex justify-center rounded-md border border-transparent bg-blue-100 px-4 py-2 text-sm font-medium text-blue-900 hover:bg-blue-200 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
           @click="onSave"
         >
           SAVE


### PR DESCRIPTION
## Summary

Cleans up Tailwind v4 utility names that were missed during the v3→v4 upgrade. No behavior change beyond restoring the original v3 visuals and a11y semantics.

- `outline-none` → `outline-hidden` (10 occurrences). v4's `outline-none` now sets `outline-style: none` and drops the invisible-outline backstop that keeps focus visible in forced-colors mode. `outline-hidden` preserves the v3 behavior.
- `shadow-sm` → `shadow-xs` (8) and bare `shadow` → `shadow-sm` (3). v4 shifted the shadow scale by one step, so the existing usages render one notch heavier than intended.
- bare `rounded` → `rounded-sm` (1). Same one-step rename for the radius scale.

Stacked on top of #98 — review/merge that one first. The base for this PR will switch to `main` once #98 lands.

## Test plan

- [x] `pnpm test` (175/175)
- [x] `pnpm compile`
- [x] `pnpm build`
- [ ] Visual smoke check: settings page focus rings, switch shadow, listbox shadow, panel shadows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)