### PR TITLE
feat(options): merge App Version row into Changelog item

### DIFF
--- a/src/components/SettingsList/ChangelogItem.vue
+++ b/src/components/SettingsList/ChangelogItem.vue
@@ -5,8 +5,11 @@ import ChangelogDialog from './ChangelogDialog.vue'
 import changelogSource from '../../../CHANGELOG.md?raw'
 import { parseChangelog } from '../../data/model/Changelog'
 
+defineProps<{
+  appVersion: string
+}>()
+
 const changelog = parseChangelog(changelogSource)
-const latestVersion = changelog.releases[0]?.version
 
 const showDialog = ref(false)
 
@@ -21,10 +24,8 @@ const handleClick = () => {
     inner-class="w-full text-left"
     @click="handleClick"
   >
-    <p>Changelog</p>
-    <template v-if="latestVersion" #subtext
-      >Latest: {{ latestVersion }}</template
-    >
+    <p>App Version: {{ appVersion }}</p>
+    <template #subtext>Click to read changelog</template>
   </SettingsListItem>
   <ChangelogDialog
     v-if="showDialog"

--- a/src/components/SettingsList/SettingsList.vue
+++ b/src/components/SettingsList/SettingsList.vue
@@ -100,11 +100,7 @@ const handleUpdateAmazonAssociateId = (id: string) => {
         @update:associate-id="handleUpdateAmazonAssociateId"
       />
       <SettingsListHeader title="Others" />
-      <SettingsListItem class="!border-t-0">
-        <p>App Version</p>
-        <template #subtext>{{ appVersion }}</template>
-      </SettingsListItem>
-      <ChangelogItem />
+      <ChangelogItem class="!border-t-0" :app-version="appVersion" />
       <SettingsListItem as="a" :href="developer.url" target="_blank">
         <p>Developer</p>
         <template #subtext>{{ developer.name }}</template>


### PR DESCRIPTION
## Summary

The Others section had two adjacent rows for related information — a static "App Version: x.y.z" row and a separate clickable "Changelog" row. This PR collapses them into a single clickable row:

- Title: "App Version: 0.0.4"
- Subtext: "Click to read changelog"
- Clicking opens the existing `ChangelogDialog`.

`ChangelogItem` gains a required `appVersion` prop, threaded through `SettingsList`.

Stacked on top of #98 — review/merge that one first. The base for this PR will switch to \`main\` once #98 lands.

## Test plan

- [x] `pnpm test` (175/175)
- [x] `pnpm compile`
- [x] `pnpm build`
- [ ] Open the options page, click the merged row, and verify the changelog dialog opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)