### PR TITLE
refactor(background): parallelize post and clipboard copy

### DIFF
--- a/src/background/OmniATP.test.ts
+++ b/src/background/OmniATP.test.ts
@@ -192,6 +192,19 @@ describe('OmniATP.postStatus', () => {
     )
   })
 
+  it('still copies to clipboard when createPost throws but the preference is enabled', async () => {
+    const bsky = buildBskyRepository({
+      createPost: vi.fn(async () => {
+        throw new Error('post fail')
+      }),
+    })
+    const { omni, chrome } = buildOmni({ bsky, prefs: buildAppPrefs(true) })
+
+    await omni.postStatus({ message: 'retry me' })
+
+    expect(chrome.copyToClipboard).toHaveBeenCalledWith('retry me')
+  })
+
   it('shows an error notification when createPost throws a generic error', async () => {
     const bsky = buildBskyRepository({
       createPost: vi.fn(async () => {
@@ -207,6 +220,13 @@ describe('OmniATP.postStatus', () => {
       'Oops! there was an error: undefined',
       'something broke'
     )
+  })
+
+  it('logs on successful post', async () => {
+    const logger = createFakeLogger()
+    const { omni } = buildOmni({ logger })
+    await omni.postStatus({ message: 'hello' })
+    expect(logger.log).toHaveBeenCalledWith('Posted', 'hello')
   })
 
   it('logs the payload before posting', async () => {

--- a/src/background/OmniATP.ts
+++ b/src/background/OmniATP.ts
@@ -6,6 +6,8 @@ import { Payload, SubCommand } from './SubCommands'
 import { XRPCError } from '@atproto/xrpc'
 import { Logger } from '../Logger'
 
+const NOTIFICATION_ICON = 'icon/128.png'
+
 const extractError = (
   e: unknown
 ): { status: number | undefined; error: string | undefined } => {
@@ -52,31 +54,41 @@ export class OmniATP {
       return
     }
 
+    this.logger.log('postStatus', payload)
+
+    await Promise.all([
+      this.submitPost(payload),
+      this.maybeCopyToClipboard(payload),
+    ])
+  }
+
+  private async submitPost(payload: Payload): Promise<void> {
     try {
-      this.logger.log('postStatus', payload)
-
       await this.bskyRepository.createPost(payload.message, payload.meta)
-
+      this.logger.log('Posted', payload.message)
       this.chrome.createNotification(
-        'icon/128.png',
+        NOTIFICATION_ICON,
         this.chrome.appName(),
         payload.message
       )
-
-      if (await this.appPreferencesRepository.shouldCopyToClipboardOnPost()) {
-        try {
-          await this.chrome.copyToClipboard(payload.message)
-        } catch (clipboardError) {
-          this.logger.error('Failed to copy to clipboard', clipboardError)
-        }
-      }
     } catch (e) {
       const { status, error } = extractError(e)
       this.chrome.createNotification(
-        'icon/128.png',
+        NOTIFICATION_ICON,
         `Oops! there was an error: ${status}`,
         error ?? 'Unknown error'
       )
+    }
+  }
+
+  private async maybeCopyToClipboard(payload: Payload): Promise<void> {
+    try {
+      if (await this.appPreferencesRepository.shouldCopyToClipboardOnPost()) {
+        await this.chrome.copyToClipboard(payload.message)
+        this.logger.log('Copied to clipboard', payload.message)
+      }
+    } catch (clipboardError) {
+      this.logger.error('Failed to copy to clipboard', clipboardError)
     }
   }
 


### PR DESCRIPTION
## Summary

- Run `bskyRepository.createPost` and clipboard copy concurrently via `Promise.all` over two new private helpers (`submitPost`, `maybeCopyToClipboard`), so the clipboard write no longer waits on the Bluesky network round-trip.
- Clipboard copy now runs even when the post throws, leaving the typed text available for retry. Previously a failed post silently dropped the clipboard step.
- Add a success log on both branches (`Posted` and `Copied to clipboard`) and pull the notification icon path into a `NOTIFICATION_ICON` module constant.

## Test plan

- [x] `pnpm test` (177 passed, +2 new cases: clipboard-on-post-failure, success-log)
- [x] `pnpm compile`