### PR TITLE
fix(options): balance vertical padding in Changelog dialog scroll area

### DIFF
--- a/src/components/SettingsList/ChangelogDialog.vue
+++ b/src/components/SettingsList/ChangelogDialog.vue
@@ -42,7 +42,7 @@ const handleClose = () => {
       >
         Changelog
       </DialogTitle>
-      <div class="mt-4 px-6 overflow-y-auto flex-1">
+      <div class="my-4 px-6 overflow-y-auto flex-1">
         <p v-if="changelog.releases.length === 0" class="text-sm text-gray-500">
           No releases yet.
         </p>


### PR DESCRIPTION
## Summary

- Switch the Changelog dialog scroll container from `mt-4` to `my-4`, so the divider above the Close button no longer sits flush against the last release item and matches the spacing under the title.

## Test plan

- [ ] Open the options page → Others → App Version → Changelog and confirm there is symmetric breathing room between the title / divider and the changelog content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)