### PR TITLE
chore: migrate Renovate config to shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,50 +1,10 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    ":pinDependencies",
-    ":pinDevDependencies",
-    ":semanticCommits"
+    "github>yshrsmz/renovate-config",
+    "github>yshrsmz/renovate-config:npm",
+    "github>yshrsmz/renovate-config:github-actions",
+    "github>yshrsmz/renovate-config:tooling"
   ],
-  "reviewers": ["yshrsmz"],
-  "lockFileMaintenance": {
-    "enabled": true
-  },
-  "dependencyDashboard": true,
-  "prConcurrentLimit": 3,
-  "packageRules": [
-    {
-      "matchManagers": ["npm"],
-      "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm runtime dependencies (non-major)",
-      "groupSlug": "npm-runtime-minor-patch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchManagers": ["npm"],
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "npm dev dependencies (non-major)",
-      "groupSlug": "npm-dev-minor-patch",
-      "semanticCommitType": "chore"
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "github-actions non-major dependencies",
-      "groupSlug": "github-actions-minor-patch",
-      "semanticCommitType": "chore"
-    },
-    {
-      "matchManagers": ["mise"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "mise non-major dependencies",
-      "groupSlug": "mise-minor-patch",
-      "semanticCommitType": "chore"
-    },
-    {
-      "matchPackageNames": ["vite", "@vitejs{/,}**"],
-      "groupName": "vitejs"
-    }
-  ]
+  "prConcurrentLimit": 1
 }


### PR DESCRIPTION
## Summary

- 個別の `renovate.json` を `yshrsmz/renovate-config` の共有 preset を extends する形に移行
- `default` / `npm` / `github-actions` / `tooling` の 4 preset を採用
- omniatp 固有の override は `prConcurrentLimit: 1` のみ保持

## 取り込まれる挙動 (preset 由来)

- timezone Asia/Tokyo / 月曜 9-12 時の schedule
- dependencyDashboard / labels=[dependencies] / minimumReleaseAge=2 weeks
- lockFileMaintenance (weekly) / vulnerability-alerts 即時対応
- npm dependencies の `:pinDependencies` / `:pinDevDependencies`
- npm dependencies → `npm dependencies` グループ / `fix(deps): ...`
- npm devDependencies → `npm devDependencies` グループ / `chore(deps): ...`
- vite / @vitejs/* → `vitejs` グループ / `chore(deps): ...`
- GitHub Actions の SHA pin + グループ化
- mise / aqua の管理ルール

## Depends on

- yshrsmz/renovate-config の対応 PR (npm preset 再構成) が **先にマージされている必要がある**

## Test plan

- [ ] マージ後、Renovate Dependency Dashboard で想定通りに PR がグループ分けされるか確認
- [ ] dependencies の PR が \`fix(deps): ...\`、devDependencies / vitejs が \`chore(deps): ...\` で生成されるか確認