### PR TITLE
fix: add pointer cursor and hover affordance to clickable settings

### DIFF
--- a/src/components/SettingsList/AmazonDomainItem.vue
+++ b/src/components/SettingsList/AmazonDomainItem.vue
@@ -35,7 +35,7 @@ const options = computed(() => [PLACEHOLDER, ...props.amazonDomains])
       <Listbox v-model="selected" class="mt-1 w-72">
         <div class="relative">
           <ListboxButton
-            class="relative w-full cursor-default rounded-md bg-white py-2 pl-3 pr-10 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-500"
+            class="relative w-full cursor-pointer rounded-md bg-white py-2 pl-3 pr-10 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-500"
           >
             <span class="block truncate">{{ selected }}</span>
             <span
@@ -65,7 +65,7 @@ const options = computed(() => [PLACEHOLDER, ...props.amazonDomains])
                 <li
                   :class="[
                     active ? 'bg-blue-100 text-blue-900' : 'text-gray-900',
-                    'relative cursor-default select-none py-2 pl-10 pr-4',
+                    'relative cursor-pointer select-none py-2 pl-10 pr-4',
                   ]"
                 >
                   <span

--- a/src/components/SettingsList/SettingsListItem.test.ts
+++ b/src/components/SettingsList/SettingsListItem.test.ts
@@ -48,4 +48,34 @@ describe('SettingsListItem', () => {
     expect(inner.classes()).toContain('!flex')
     expect(inner.classes()).toContain('items-center')
   })
+
+  it('applies interactive affordance classes when rendered as a button', () => {
+    const wrapper = mount(SettingsListItem, {
+      props: { as: 'button' },
+      slots: { default: 'x' },
+    })
+    const button = wrapper.find('button')
+    expect(button.classes()).toContain('cursor-pointer')
+    expect(button.classes()).toContain('hover:bg-gray-50')
+  })
+
+  it('applies interactive affordance classes when rendered as an anchor', () => {
+    const wrapper = mount(SettingsListItem, {
+      props: { as: 'a' },
+      attrs: { href: 'https://example.com' },
+      slots: { default: 'x' },
+    })
+    const anchor = wrapper.find('a')
+    expect(anchor.classes()).toContain('cursor-pointer')
+    expect(anchor.classes()).toContain('hover:bg-gray-50')
+  })
+
+  it('does not apply interactive affordance classes for the default div', () => {
+    const wrapper = mount(SettingsListItem, {
+      slots: { default: 'x' },
+    })
+    const inner = wrapper.find('li > div')
+    expect(inner.classes()).not.toContain('cursor-pointer')
+    expect(inner.classes()).not.toContain('hover:bg-gray-50')
+  })
 })

--- a/src/components/SettingsList/SettingsListItem.vue
+++ b/src/components/SettingsList/SettingsListItem.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { computed, defineComponent, useAttrs } from 'vue'
 
-withDefaults(defineProps<{ as?: string; innerClass?: string }>(), {
-  as: 'div',
-  innerClass: '',
-})
+const props = withDefaults(
+  defineProps<{ as?: string; innerClass?: string }>(),
+  {
+    as: 'div',
+    innerClass: '',
+  }
+)
 
 const COMPONENT_NAME = 'SettingsListItem'
 
@@ -14,6 +17,8 @@ const excludedAttrs = computed(() => {
   const { ['class']: c, ...excluded } = attrs
   return excluded
 })
+
+const isInteractive = computed(() => props.as === 'button' || props.as === 'a')
 </script>
 
 <script lang="ts">
@@ -27,7 +32,13 @@ export default defineComponent({
     <component
       :is="as"
       v-bind="excludedAttrs"
-      :class="['block px-6 py-4 text-base', innerClass]"
+      :class="[
+        'block px-6 py-4 text-base',
+        isInteractive
+          ? 'cursor-pointer hover:bg-gray-50 transition-colors'
+          : '',
+        innerClass,
+      ]"
     >
       <slot />
       <div v-if="$slots.subtext" class="text-gray-600 text-sm">

--- a/src/style.css
+++ b/src/style.css
@@ -1,2 +1,9 @@
 @import 'tailwindcss';
 @plugin "@tailwindcss/forms";
+
+@layer base {
+  button:not(:disabled),
+  [role='button']:not([aria-disabled='true']) {
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
## Summary

- Tailwind v4 makes `<button>` default to `cursor: default`, and the Amazon-domain Listbox carried `cursor-default` from the Headless UI sample, so several elements in the options page did not visually look clickable even though they were semantically buttons or links.
- Adds a base-layer CSS rule giving every non-disabled `<button>` (and `[role='button']:not([aria-disabled='true'])`) `cursor: pointer`, fixing the Sign in / Sign out buttons and every dialog button at once.
- In `SettingsListItem`, the inner element now also gets `cursor-pointer hover:bg-gray-50 transition-colors` when `as` is `'button'` or `'a'`, giving button-row entries (App Version row, link rows, etc.) a hover background.
- Swaps the Amazon-domain Listbox button and option items from `cursor-default` to `cursor-pointer`.

A latent refactor of `SettingsListItem`'s `class` forwarding split is deferred to #144.

## Test plan

- [x] `pnpm compile` passes
- [x] `pnpm test` (188 tests, including 3 new ones covering interactive class application) passes
- [x] `pnpm lint:fix` clean
- [ ] Manual `pnpm dev` smoke: hover/click each of these in the options page and confirm pointer cursor + (for row-level cases) hover background:
  - App Version row → opens Changelog dialog
  - Amazon Associate ID row → opens text input dialog
  - Post Prefix row → opens text input dialog
  - Developer / Store / 3rd external links → open in new tab
  - Amazon Domain dropdown button and each option
  - Sign in / Sign out buttons in the auth row
  - All dialog buttons (Cancel, Save, Sign in, Sign out, Close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)