### PR TITLE
refactor(SettingsListItem): forward all attrs (including `class`) to the inner element

### DIFF
--- a/src/components/SettingsList/SettingsListItem.test.ts
+++ b/src/components/SettingsList/SettingsListItem.test.ts
@@ -78,4 +78,22 @@ describe('SettingsListItem', () => {
     expect(inner.classes()).not.toContain('cursor-pointer')
     expect(inner.classes()).not.toContain('hover:bg-gray-50')
   })
+
+  it('forwards parent-provided class to the inner element, not the <li>', () => {
+    const wrapper = mount(SettingsListItem, {
+      props: { as: 'button' },
+      attrs: { class: 'bg-blue-500' },
+      slots: { default: 'x' },
+    })
+    const button = wrapper.find('button')
+    expect(button.classes()).toContain('bg-blue-500')
+    expect(wrapper.find('li').classes()).not.toContain('bg-blue-500')
+  })
+
+  it('keeps the SettingsListItem identifier class on the <li>', () => {
+    const wrapper = mount(SettingsListItem, {
+      slots: { default: 'x' },
+    })
+    expect(wrapper.find('li').classes()).toContain('SettingsListItem')
+  })
 })

--- a/src/components/SettingsList/SettingsListItem.vue
+++ b/src/components/SettingsList/SettingsListItem.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { computed, defineComponent, useAttrs } from 'vue'
+import { computed } from 'vue'
+
+defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(
   defineProps<{ as?: string; innerClass?: string }>(),
@@ -9,29 +11,14 @@ const props = withDefaults(
   }
 )
 
-const COMPONENT_NAME = 'SettingsListItem'
-
-const attrs = useAttrs()
-
-const excludedAttrs = computed(() => {
-  const { ['class']: c, ...excluded } = attrs
-  return excluded
-})
-
 const isInteractive = computed(() => props.as === 'button' || props.as === 'a')
 </script>
 
-<script lang="ts">
-export default defineComponent({
-  inheritAttrs: false,
-})
-</script>
-
 <template>
-  <li :class="[COMPONENT_NAME, $attrs.class]">
+  <li class="SettingsListItem">
     <component
       :is="as"
-      v-bind="excludedAttrs"
+      v-bind="$attrs"
       :class="[
         'block px-6 py-4 text-base',
         isInteractive


### PR DESCRIPTION
## Summary

- Forward all attrs (including `class`) on `<SettingsListItem>` to the inner `<component :is="as">` instead of splitting them between the outer `<li>` and the inner element.
- Keep the `<li>` as a minimal semantic shell with only the static `SettingsListItem` identifier class.
- Replace the dual `<script>` + `defineComponent({ inheritAttrs: false })` with `defineOptions({ inheritAttrs: false })` inside `<script setup>` and drop the now-unused `useAttrs` / `excludedAttrs` plumbing.

Closes #144.

## Why

Before this PR, `SettingsListItem` placed parent-supplied `class` on the outer `<li>` while non-`class` attrs and the interactive Tailwind classes (`cursor-pointer hover:bg-gray-50 transition-colors`) landed on the inner `<component>`. A consumer like `<SettingsListItem as="button" class="bg-blue-500" @click="…">` would produce a visually inconsistent row (the `<li>` background blue, the inner button transparent, hover swapping the inner cell to gray-50 against the surrounding blue). This was latent — no current consumer triggers the split — but forecloses a natural override pattern.

Forwarding everything to the inner element matches the convention used by Headless UI's transparent wrapper components and removes the foot-gun.

Impact assessment:

- `grep` confirms `.SettingsListItem` and `.SettingsListHeader` are not used as CSS selectors anywhere in the codebase, so moving the `SettingsListHeader` identifier class onto the inner `<div>` is invisible to users.
- The only consumer that currently passes a class through `<SettingsListItem>` is `SettingsListHeader` (`as="div"`, non-interactive); no current visual conflict exists either before or after.
- `<ChangelogItem class="!border-t-0" />` in `SettingsList.vue:103` is unrelated dead code (multi-root template drops the attr on the `ChangelogItem` side, both before and after this PR); tracked separately in #147.

## Changes

- `src/components/SettingsList/SettingsListItem.vue` — `inheritAttrs: false` via `defineOptions`, `v-bind="$attrs"` on the inner `<component>`, static `class="SettingsListItem"` on the `<li>`. Drop `COMPONENT_NAME`, `useAttrs()`, `excludedAttrs`, and the secondary `<script>` block.
- `src/components/SettingsList/SettingsListItem.test.ts` — add two tests:
  - parent-provided `class` lands on the inner element, not on the `<li>`, when `as="button"`;
  - the `SettingsListItem` identifier class remains on the `<li>`.

## Test plan

- [x] `pnpm test` — 190/190 green (including the two new tests)
- [x] `pnpm compile` — clean
- [x] `pnpm lint:fix` — no changes / no errors
- [ ] Manually load the unpacked dev build (`pnpm dev`) and confirm the options page renders identically (header rows, auth row, post prefix, copy-to-clipboard toggle, Amazon section, changelog button, developer/store/privacy links).
- [ ] Confirm hover affordance on interactive rows (button, anchor) still shows `cursor: pointer` + `bg-gray-50`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)