### PR TITLE
fix(SettingsList): drop dead `!border-t-0` on ChangelogItem

### DIFF
--- a/src/components/SettingsList/SettingsList.vue
+++ b/src/components/SettingsList/SettingsList.vue
@@ -100,7 +100,7 @@ const handleUpdateAmazonAssociateId = (id: string) => {
         @update:associate-id="handleUpdateAmazonAssociateId"
       />
       <SettingsListHeader title="Others" />
-      <ChangelogItem class="!border-t-0" :app-version="appVersion" />
+      <ChangelogItem :app-version="appVersion" />
       <SettingsListItem as="a" :href="developer.url" target="_blank">
         <p>Developer</p>
         <template #subtext>{{ developer.name }}</template>


### PR DESCRIPTION
## Summary

- `<ChangelogItem class="!border-t-0" :app-version="appVersion" />` in `SettingsList.vue` was a no-op: `ChangelogItem` has a multi-root template (`<SettingsListItem>` + conditional `<ChangelogDialog>`), so Vue 3 does not auto-fallthrough `$attrs`. The class was silently dropped and produced a `[Vue warn]: Extraneous non-props attributes (class)` warning in dev.
- No row container in the codebase draws `border-t`, so the override was overriding nothing. Per the issue's recommended option 1, just remove it.

Closes #147

## Test plan

- [x] `pnpm compile` — green
- [x] `pnpm test` — 190 / 190 passing
- [x] `pnpm lint:fix` — clean
- [ ] `pnpm dev` and confirm no `Extraneous non-props attributes` warning fires for `ChangelogItem`, and the Changelog row still renders identically (no `border-t` was ever visible to begin with)

🤖 Generated with [Claude Code](https://claude.com/claude-code)